### PR TITLE
summer olympic api

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -30,6 +30,11 @@
             <scope>runtime</scope>
             <version>2.1.210</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>3.3.2</version>
+        </dependency>    
     </dependencies>
 
     <properties>

--- a/backend/src/main/java/com/interview/Entities/OlympicTeam.java
+++ b/backend/src/main/java/com/interview/Entities/OlympicTeam.java
@@ -1,0 +1,102 @@
+package com.interview.Entities;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Generated;
+import org.hibernate.annotations.GenerationTime;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+@Entity
+@Table(name = "olympicteams")
+public class OlympicTeam {
+
+    @Id
+    @Generated(GenerationTime.INSERT)
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "id", updatable = false, nullable = false)
+    public Integer id;
+
+    @Column(name = "team_country", nullable = false, unique = true)
+    public String teamCountry;
+
+    @Column(name = "total_athletes", nullable = false)
+    public Integer totalAthletes;
+
+    @Column(name = "created_at", nullable = false)
+    @CreationTimestamp
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm", shape = JsonFormat.Shape.STRING)
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm", iso = ISO.DATE_TIME)
+    public LocalDateTime createdAt;
+
+    @Column(name = "updated_on", nullable = true)
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm", shape = JsonFormat.Shape.STRING)
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm", iso = ISO.DATE_TIME)
+    public LocalDateTime updatedOn;
+
+    @Column(name = "disabled_on", nullable = true)
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm", shape = JsonFormat.Shape.STRING)
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm", iso = ISO.DATE_TIME)
+    public LocalDateTime disabledOn;
+
+    public OlympicTeam() {
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getTeamCountry() {
+        return teamCountry;
+    }
+
+    public void setTeamCountry(String teamCountry) {
+        this.teamCountry = teamCountry;
+    }
+
+    public Integer getTotalAthletes() {
+        return totalAthletes;
+    }
+
+    public void setTotalAthletes(Integer totalAthletes) {
+        this.totalAthletes = totalAthletes;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedOn() {
+        return updatedOn;
+    }
+
+    public void setUpdatedOn(LocalDateTime updatedOn) {
+        this.updatedOn = updatedOn;
+    }
+
+    public LocalDateTime getDisabledOn() {
+        return disabledOn;
+    }
+
+    public void setDisabledOn(LocalDateTime disabledOn) {
+        this.disabledOn = disabledOn;
+    }
+
+    public static OlympicTeam fuzzOlympicTeam() {
+        OlympicTeam user = new OlympicTeam();
+        user.totalAthletes = 123;
+        user.teamCountry = "Spain";
+        // everything else is either auto-generated or nullable
+        return user;
+    }
+
+}

--- a/backend/src/main/java/com/interview/Repositories/OlympicTeamsRepository.java
+++ b/backend/src/main/java/com/interview/Repositories/OlympicTeamsRepository.java
@@ -1,0 +1,17 @@
+package com.interview.Repositories;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.interview.Entities.OlympicTeam;
+
+public interface OlympicTeamsRepository extends JpaRepository<OlympicTeam, Long> {
+
+    OlympicTeam findById(Integer id);
+
+    @Query(value = "SELECT * FROM olympicteams ot WHERE ot.disabled_on IS NULL", nativeQuery = true)
+    List<OlympicTeam> findByDisabledOnIsNotNull();
+
+}

--- a/backend/src/main/java/com/interview/Services/OlympicTeamsService.java
+++ b/backend/src/main/java/com/interview/Services/OlympicTeamsService.java
@@ -1,0 +1,54 @@
+package com.interview.Services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.interview.Entities.OlympicTeam;
+import com.interview.Repositories.OlympicTeamsRepository;
+
+import java.util.List;
+
+import javax.persistence.EntityNotFoundException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Service
+public class OlympicTeamsService {
+
+    @Autowired
+    private OlympicTeamsRepository repo;
+    private static final Logger logger = LoggerFactory.getLogger(OlympicTeamsService.class);
+
+    public OlympicTeam GetOlympicTeamById(Integer id) {
+        logger.info("retrieving olympic team for id: " + id);
+        return repo.findById(id);
+    }
+
+    // retrieves all active (non-disabled) olympic teams
+    public List<OlympicTeam> GetAllOlympicTeams() {
+        logger.info("retrieving all 2024 summer olympic teams");
+        return repo.findByDisabledOnIsNotNull();
+    }
+
+    public OlympicTeam CreateOlympicTeam(OlympicTeam olympicTeam) {
+        logger.info("creating summer olympic team name: " + olympicTeam.teamCountry);
+        return repo.save(olympicTeam);
+    }
+
+    // updates (and soft-deletes) olympic teams
+    public OlympicTeam UpdateOlympicTeam(Integer id, OlympicTeam updatedOlympicTeam) {
+        logger.info("updating summer olympic team by ID: " + id);
+        OlympicTeam existingTeam = repo.findById(id);
+
+        if (existingTeam == null) {
+            throw new EntityNotFoundException("Olympic Team not found");
+        }
+        existingTeam.setTeamCountry(updatedOlympicTeam.getTeamCountry());
+        existingTeam.setTotalAthletes(updatedOlympicTeam.getTotalAthletes());
+        existingTeam.setUpdatedOn(updatedOlympicTeam.getUpdatedOn());
+        existingTeam.setDisabledOn(updatedOlympicTeam.getDisabledOn());
+
+        return repo.save(existingTeam);
+    }
+}

--- a/backend/src/main/java/com/interview/controllers/ErrorResponse.java
+++ b/backend/src/main/java/com/interview/controllers/ErrorResponse.java
@@ -1,0 +1,15 @@
+package com.interview.controllers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+public class ErrorResponse {
+    public HttpStatus status;
+    public String errorMessage;
+
+    @Autowired
+    public ErrorResponse(HttpStatus status, String message) {
+        this.status = status;
+        this.errorMessage = message;
+    }
+}

--- a/backend/src/main/java/com/interview/controllers/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/interview/controllers/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.interview.controllers;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+
+@ControllerAdvice(annotations = RestController.class)
+public class GlobalExceptionHandler {
+
+    // this is a global exception handler - should any exception occur stemming from
+    // any restcontroller methods, then this should give the client a detailed
+    // description as to why
+    @ExceptionHandler(value = { Exception.class })
+    public ResponseEntity<Object> handleException(Exception ex) {
+        ErrorResponse error = new ErrorResponse(HttpStatus.BAD_REQUEST, ex.getCause().getCause().getMessage());
+        return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/backend/src/main/java/com/interview/controllers/OlympicTeamsController.java
+++ b/backend/src/main/java/com/interview/controllers/OlympicTeamsController.java
@@ -1,0 +1,65 @@
+package com.interview.controllers;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import com.interview.Entities.OlympicTeam;
+import com.interview.Services.OlympicTeamsService;
+
+@RestController
+public class OlympicTeamsController {
+
+  @Autowired
+  private final OlympicTeamsService service;
+
+  OlympicTeamsController(OlympicTeamsService service) {
+    this.service = service;
+  }
+
+  @GetMapping("/api/teams")
+  public ResponseEntity<List<OlympicTeam>> GetOlympicTeams() {
+
+    List<OlympicTeam> teams = service.GetAllOlympicTeams();
+    if (teams.size() > 0) {
+      return new ResponseEntity<>(teams, HttpStatus.OK);
+    }
+    return new ResponseEntity<>(teams, HttpStatus.NO_CONTENT);
+
+  }
+
+  @GetMapping("/api/teams/{id}")
+  public ResponseEntity<OlympicTeam> GetOlympicTeamById(@PathVariable Integer id) {
+
+    OlympicTeam team = service.GetOlympicTeamById(id);
+    if (team != null) {
+      return new ResponseEntity<>(team, HttpStatus.OK);
+    }
+    return new ResponseEntity<>(team, HttpStatus.NOT_FOUND);
+
+  }
+
+  @PostMapping("/api/teams")
+  public ResponseEntity<OlympicTeam> CreateOlympicTeam(@RequestBody OlympicTeam olympicTeam) {
+
+    OlympicTeam team = service.CreateOlympicTeam(olympicTeam);
+    return new ResponseEntity<>(team, HttpStatus.CREATED);
+  }
+
+  // PATCH instead of PUT b/c only want to update specific olympic team fields
+  @PatchMapping("/api/teams/{id}")
+  public ResponseEntity<OlympicTeam> UpdateOlympicTeam(@PathVariable Integer id,
+      @RequestBody OlympicTeam updatedOlympicTeam) {
+
+    OlympicTeam team = service.UpdateOlympicTeam(id, updatedOlympicTeam);
+    return new ResponseEntity<>(team, HttpStatus.OK);
+  }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -4,3 +4,12 @@ spring.datasource.username=sa
 spring.datasource.password=password
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.h2.console.enabled=true
+# spring.datasource.data = classpath:database/data.sql
+spring.jpa.hibernate.ddl-auto=update
+hibernate.dialect=org.hibernate.dialect.H2Dialect
+spring.jpa.properties.hibernate.id.new_generator_mappings=true
+spring.jpa.hibernate.use-new-id-generator-mappings
+# spring.sql.init.mode=never
+# spring.datasource.initialize=false
+spring.jpa.properties.hibernate.jdbc.time_zone=UTC
+

--- a/backend/src/main/resources/database/data.sql
+++ b/backend/src/main/resources/database/data.sql
@@ -1,1 +1,13 @@
 -- Provide SQL scripts here
+
+-- kept this sql file commented out on purpose
+-- olympicteams table created from entity annotation
+-- NOTE - commented out the application properties path to this file so that the auto-increment configuration would not error when creating a new resource via POST
+
+
+-- INSERT INTO olympicteams (id, team_country, total_athletes, created_at, updated_on, disabled_on)
+-- VALUES 
+--     (1, 'USA', 650, '2024-08-12', null, null),
+--     (2, 'Great Britain', 475, '2024-08-12', null, '2024-08-12'); 
+
+

--- a/backend/src/test/java/OlympicTeamsServiceTest.java
+++ b/backend/src/test/java/OlympicTeamsServiceTest.java
@@ -1,0 +1,79 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+// import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import com.interview.Application;
+import com.interview.Entities.OlympicTeam;
+import com.interview.Repositories.OlympicTeamsRepository;
+import com.interview.Services.OlympicTeamsService;
+
+@ExtendWith(MockitoExtension.class)
+@SpringBootTest(classes = Application.class)
+class OlympicTeamsServiceTest {
+
+    @Autowired
+    private OlympicTeamsService olympicTeamsService;
+
+    @MockBean
+    private OlympicTeamsRepository repo;
+
+    @Test
+    void testGetOlympicTeamById_Found() {
+        // Arrange
+        Integer fakeID = 1;
+        OlympicTeam fuzzedTeam = OlympicTeam.fuzzOlympicTeam();
+
+        when(repo.findById(fakeID)).thenReturn(fuzzedTeam);
+
+        // Act
+        OlympicTeam actualTeam = olympicTeamsService.GetOlympicTeamById(fakeID);
+
+        // Assert
+        assertEquals(actualTeam, fuzzedTeam);
+    }
+
+    @Test
+    void testGetOlympicTeamById_NotFound() {
+        // Arrange
+        Integer fakeID = 1;
+        OlympicTeam fuzzedTeam = OlympicTeam.fuzzOlympicTeam();
+
+        when(repo.findById(fakeID)).thenReturn(fuzzedTeam);
+
+        // Act - given 987 id does not exist on mocked repo layer
+        OlympicTeam actualTeam = olympicTeamsService.GetOlympicTeamById(987);
+
+        // Assert
+        assertNotEquals(actualTeam, fuzzedTeam);
+        assertEquals(actualTeam, null);
+    }
+
+    // =============================================
+    // Get all olympic teams
+    // =============================================
+    @Test
+    void testGetOlympicTeams_NonEmpty() {
+        // Arrange
+        OlympicTeam fuzzedTeam = OlympicTeam.fuzzOlympicTeam();
+        List<OlympicTeam> fuzzedTeams = List.of(fuzzedTeam);
+
+        when(repo.findByDisabledOnIsNotNull()).thenReturn(fuzzedTeams);
+
+        // Act - given 987 id does not exist on mocked repo layer
+        List<OlympicTeam> actualTeams = olympicTeamsService.GetAllOlympicTeams();
+
+        // Assert
+        assertEquals(actualTeams, fuzzedTeams);
+        assertEquals(actualTeams.size(), 1);
+    }
+}


### PR DESCRIPTION
The goal of this PR was to create a non-convoluted API to provide CRUD functionality for Olympic team data.

Considerations
### 1) tests
- only wrote a few service tests that show the execution of the service methods, with the mocking of the repo results to isolate the "unit testing" to just the service.
- I did not extend this testing to the controller methods, since I hit my personal time limit for the assessment.

### 2) entity objects used for dto's as well, for simplicity
- typically I'd have a "toDTO" and "fromDTO" in the service methods to have client-specific objects that the API returns, but I did not add this in the MVP for the sake of time.

### 3) update readme
- really nothing to add to the readme for the sake of the assessment, outside of maybe including some example postman requests, which I can just go over during the in-person portion.
