### PR TITLE
[ionutbalutoiu] Implement SRE Platform Interview Project

### DIFF
--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -1,0 +1,40 @@
+name: Deploy Production
+
+on:
+  release:
+    types:
+      - released
+
+concurrency:
+  group: production_deployments
+
+jobs:
+  backend-build:
+    uses: ./.github/workflows/reusable-build-push-image.yaml
+    secrets:
+      registry_user_password: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      registry: ghcr.io
+      registry_user_name: ${{ github.actor }}
+      image: ionutbalutoiu/tekmetric-interview-backend
+      tags: |
+        ${{ github.event.release.tag_name }}
+      platforms: linux/amd64
+      context: ./backend
+
+  backend-deploy:
+    needs: backend-build
+    uses: ./.github/workflows/reusable-deploy-helm-release.yaml
+    secrets:
+      kubeconfig_base64: ${{ secrets.PRODUCTION_KUBECONFIG_BASE64 }}
+    with:
+      kubernetes_namespace: backend-production
+      release_name: backend-production
+      oci_chart: oci://ghcr.io/ionutbalutoiu/chart-tekmetric-app
+      oci_chart_version: 1.0.0
+      helm_opts: >
+        --atomic
+        --wait
+        --set image.tag=${{ github.event.release.tag_name }}
+        -f ./platform/helm_values/backend/production/values.yaml
+        -f ./platform/helm_values/backend/production/secrets.yaml

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -1,0 +1,40 @@
+name: Deploy Staging
+
+on:
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: staging_deployments
+
+jobs:
+  backend-build:
+    uses: ./.github/workflows/reusable-build-push-image.yaml
+    secrets:
+      registry_user_password: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      registry: ghcr.io
+      registry_user_name: ${{ github.actor }}
+      image: ionutbalutoiu/tekmetric-interview-backend
+      tags: |
+        latest
+        ${{ github.sha }}
+      platforms: linux/amd64
+      context: ./backend
+
+  backend-deploy:
+    needs: backend-build
+    uses: ./.github/workflows/reusable-deploy-helm-release.yaml
+    secrets:
+      kubeconfig_base64: ${{ secrets.STAGING_KUBECONFIG_BASE64 }}
+    with:
+      kubernetes_namespace: backend-staging
+      release_name: backend-staging
+      local_chart_path: ./platform/charts/tekmetric-app
+      helm_opts: >
+        --atomic
+        --wait
+        --set image.tag=${{ github.sha }}
+        -f ./platform/helm_values/backend/staging/values.yaml
+        -f ./platform/helm_values/backend/staging/secrets.yaml

--- a/.github/workflows/release-helm-charts.yaml
+++ b/.github/workflows/release-helm-charts.yaml
@@ -1,0 +1,35 @@
+name: Release Helm Charts
+
+on:
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: helm_charts_releases
+
+jobs:
+  release-helm-charts:
+    permissions:
+      contents: read
+      packages: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Release all platform Helm charts
+        shell: bash
+        run: ./platform/scripts/release-helm-charts.sh
+        env:
+          OCI_REGISTRY_URL: ghcr.io
+          OCI_REGISTRY_NAMESPACE: ${{ github.actor }}

--- a/.github/workflows/reusable-build-push-image.yaml
+++ b/.github/workflows/reusable-build-push-image.yaml
@@ -1,0 +1,98 @@
+name: Reusable - Build and Push Container Image
+
+on:
+  workflow_call:
+    secrets:
+      registry_user_password:
+        description: "Container registry user password"
+        required: true
+
+    inputs:
+      registry:
+        required: true
+        type: string
+        description: "Container registry URL"
+
+      registry_user_name:
+        required: true
+        type: string
+        description: "Container registry user name"
+
+      image:
+        required: true
+        type: string
+        description: "Container image name"
+
+      # NOTE: Documented at: https://github.com/docker/metadata-action?tab=readme-ov-file#tags-input
+      tags:
+        required: true
+        type: string
+        description: "Container image tags (the format is the same as 'tags' input from 'docker/metadata-action')"
+
+      platforms:
+        required: true
+        type: string
+        description: "List (given as comma-delimited string) of target platforms for the container image"
+
+      context:
+        required: true
+        type: string
+        description: "Context path for Docker buildx"
+
+      file:
+        required: false
+        type: string
+        description: "Dockerfile path. It defaults to: ${context}/Dockerfile"
+
+      build_args:
+        required: false
+        type: string
+        description: "Build arguments for Docker buildx"
+
+    outputs:
+      tags:
+        description: "Container image tags"
+        value: ${{ jobs.docker-buildx.outputs.tags }}
+
+jobs:
+  docker-buildx:
+    runs-on: ubuntu-latest
+
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ inputs.registry_user_name }}
+          password: ${{ secrets.registry_user_password }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ inputs.registry }}/${{ inputs.image }}
+          tags: ${{ inputs.tags }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: ${{ inputs.platforms }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          context: ${{ inputs.context }}
+          file: ${{ inputs.file }}
+          build-args: ${{ inputs.build_args }}
+          pull: true
+          push: true

--- a/.github/workflows/reusable-deploy-helm-release.yaml
+++ b/.github/workflows/reusable-deploy-helm-release.yaml
@@ -1,0 +1,67 @@
+name: Reusable - Deploy Helm release
+
+on:
+  workflow_call:
+    secrets:
+      kubeconfig_base64:
+        description: "Kubeconfig file content (base64-encoded)"
+        required: true
+
+    inputs:
+      kubernetes_namespace:
+        required: true
+        type: string
+        description: "Kubernetes namespace"
+
+      release_name:
+        required: true
+        type: string
+        description: "Helm release name"
+
+      helm_opts:
+        required: false
+        type: string
+        description: "Helm options"
+
+      local_chart_path:
+        required: false
+        type: string
+        description: "Local path to Helm chart"
+
+      oci_chart:
+        required: false
+        type: string
+        description: "Helm chart from OCI registry"
+
+      oci_chart_version:
+        required: false
+        type: string
+        description: "Helm chart version (required if oci_chart is set)"
+
+jobs:
+  helm-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup KUBECONFIG
+        shell: bash
+        run: |
+          set -e
+          mkdir -p ${HOME}/.kube
+          touch ${HOME}/.kube/config
+          chmod 600 ${HOME}/.kube/config
+          echo "${{ secrets.KUBECONFIG_BASE64 }}" | base64 -d > ${HOME}/.kube/config
+
+      - name: Deploy Helm release
+        shell: bash
+        run: ./platform/scripts/deploy-helm-release.sh
+        env:
+          HELM_NAMESPACE: ${{ inputs.kubernetes_namespace }}
+          HELM_RELEASE_NAME: ${{ inputs.release_name }}
+          HELM_OPTS: ${{ inputs.helm_opts }}
+          LOCAL_CHART_PATH: ${{ inputs.local_chart_path }}
+          HELM_OCI_CHART: ${{ inputs.oci_chart }}
+          HELM_OCI_CHART_VERSION: ${{ inputs.oci_chart_version }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 frontend/node_modules
+backend/.vscode/*
 backend/.idea/*
 backend/*.iml
 backend/target/**
+platform/charts/**/charts
+platform/charts/**/*.tgz
 
 # ignoring the .idea folder
 .idea

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,26 @@
+#
+# Build and package the application using Maven
+#
+FROM maven:3-amazoncorretto-21 AS maven_builder
+
+# Copy the source code
+WORKDIR /app
+COPY . ./
+
+# Build the application
+RUN mvn package
+
+#
+# Main app image
+#
+FROM amazoncorretto:21.0.5-al2
+
+# Copy the built jar file
+WORKDIR /app
+COPY --from=maven_builder /app/target/interview-1.0-SNAPSHOT.jar /app/interview-app.jar
+
+# Expose default HTTP port
+EXPOSE 8080/tcp
+
+# Run the application
+CMD ["java", "-jar", "/app/interview-app.jar"]

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -11,29 +11,40 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.1.RELEASE</version>
+        <version>3.3.5</version>
     </parent>
 
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+            <version>3.3.5</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
-            <version>2.1.4.RELEASE</version>
+            <version>3.3.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <version>3.3.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>1.13.6</version>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>runtime</scope>
-            <version>2.1.210</version>
+            <version>2.3.232</version>
         </dependency>
     </dependencies>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>21</java.version>
     </properties>
 
 
@@ -42,6 +53,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>3.3.5</version>
             </plugin>
         </plugins>
     </build>

--- a/backend/src/main/java/com/interview/resource/HealthCheckResource.java
+++ b/backend/src/main/java/com/interview/resource/HealthCheckResource.java
@@ -1,0 +1,25 @@
+package com.interview.resource;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthCheckResource {
+
+    // To be used for readiness probe
+    @RequestMapping("/api/health_check")
+    public String health() {
+        // NOTE: It should contain logic to check if the application is ready
+        // to serve traffic.
+
+        return "OK";
+    }
+
+    // To be used for liveness probe
+    @RequestMapping("/api/ping")
+    public String ping() {
+        // NOTE: This is a simple endpoint to check if the application is alive (up and running).
+
+        return "pong";
+    }
+}

--- a/backend/src/main/java/com/interview/resource/HomeResource.java
+++ b/backend/src/main/java/com/interview/resource/HomeResource.java
@@ -1,0 +1,23 @@
+package com.interview.resource;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HomeResource {
+
+    // Simple home page handler. It returns the hostname and host address of the server.
+    @RequestMapping("/")
+    public String index() {
+        String hostName = "", hostAddress = "";
+
+        try {
+            hostName = java.net.InetAddress.getLocalHost().getHostName();
+            hostAddress = java.net.InetAddress.getLocalHost().getHostAddress();
+        } catch (java.net.UnknownHostException e) {
+            e.printStackTrace();
+        }
+
+        return String.format("Welcome to '%s' (%s) home!\n", hostName, hostAddress);
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+management.endpoint.health.show-details=always
+management.endpoints.web.exposure.include=*
 spring.datasource.url=jdbc:h2:mem:testdb
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa

--- a/platform/charts/tekmetric-app/.helmignore
+++ b/platform/charts/tekmetric-app/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/platform/charts/tekmetric-app/Chart.yaml
+++ b/platform/charts/tekmetric-app/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: chart-tekmetric-app
+description: A base Helm chart to deploy the Tekmetric apps
+type: application
+version: 1.0.0
+appVersion: latest

--- a/platform/charts/tekmetric-app/templates/_helpers.tpl
+++ b/platform/charts/tekmetric-app/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tekmetric-app.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tekmetric-app.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tekmetric-app.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "tekmetric-app.labels" -}}
+helm.sh/chart: {{ include "tekmetric-app.chart" . }}
+{{ include "tekmetric-app.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "tekmetric-app.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tekmetric-app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "tekmetric-app.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "tekmetric-app.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/platform/charts/tekmetric-app/templates/configmap.yaml
+++ b/platform/charts/tekmetric-app/templates/configmap.yaml
@@ -1,0 +1,20 @@
+{{- $fullname := include "tekmetric-app.fullname" . }}
+
+{{- range $nameSuffix, $configmap := .Values.configMaps }}
+{{- if $configmap.data }}
+{{- $name := default (printf "%s-%s" $fullname $nameSuffix) $configmap.name }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ (tpl $name $) | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- include "tekmetric-app.labels" $ | nindent 4 }}
+  {{- with .annotations }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+data:
+  {{- $configmap.data | toYaml | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/platform/charts/tekmetric-app/templates/deployment.yaml
+++ b/platform/charts/tekmetric-app/templates/deployment.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tekmetric-app.fullname" . }}
+  labels:
+    {{- include "tekmetric-app.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "tekmetric-app.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "tekmetric-app.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "tekmetric-app.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.app.command }}
+          command:
+            {{ .Values.app.command | nindent 12 }}
+          {{- end }}
+          {{- if .Values.app.args }}
+          args:
+            {{ .Values.app.args | nindent 12 }}
+          {{- end }}
+          envFrom:
+          {{- range .Values.app.envFrom }}
+          {{- if eq (lower .source) "configmap" }}
+            - configMapRef:
+                name: {{ tpl .name $ }}
+          {{- end }}
+          {{- if eq (lower .source) "secret" }}
+            - secretRef:
+                name: {{ tpl .name $ }}
+          {{- end }}
+          {{- end }}
+          ports:
+          {{- range .Values.app.ports }}
+            - name: {{ .name }}
+              containerPort: {{ .number }}
+              protocol: {{ .protocol | default "TCP" }}
+          {{- end }}
+          {{- if .Values.app.healthCheck.livenessProbe.enabled }}
+          livenessProbe:
+            {{- toYaml .Values.app.healthCheck.livenessProbe.spec | nindent 12 }}
+          {{- end }}
+          {{- if .Values.app.healthCheck.readinessProbe.enabled }}
+          readinessProbe:
+            {{- toYaml .Values.app.healthCheck.readinessProbe.spec | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.app.volumeMounts }}
+          volumeMounts:
+            {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+      {{- with .Values.app.volumes }}
+      volumes:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/platform/charts/tekmetric-app/templates/hpa.yaml
+++ b/platform/charts/tekmetric-app/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "tekmetric-app.fullname" . }}-hpa
+  labels:
+    {{- include "tekmetric-app.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "tekmetric-app.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/platform/charts/tekmetric-app/templates/ingress.yaml
+++ b/platform/charts/tekmetric-app/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "tekmetric-app.fullname" . }}
+  labels:
+    {{- include "tekmetric-app.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "tekmetric-app.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/platform/charts/tekmetric-app/templates/pdb.yaml
+++ b/platform/charts/tekmetric-app/templates/pdb.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "tekmetric-app.fullname" . }}-pdb
+  labels:
+    {{- include "tekmetric-app.labels" . | nindent 4 }}
+spec:
+  maxUnavailable: {{ .Values.pdb.maxUnavailable | default 1 }}
+  {{- with .Values.pdb.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "tekmetric-app.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/platform/charts/tekmetric-app/templates/secret.yaml
+++ b/platform/charts/tekmetric-app/templates/secret.yaml
@@ -1,0 +1,21 @@
+{{- $fullname := include "tekmetric-app.fullname" . }}
+
+{{- range $nameSuffix, $secret := .Values.secrets }}
+{{- if $secret.data }}
+{{- $name := default (printf "%s-%s" $fullname $nameSuffix) $secret.name }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ (tpl $name $) | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- include "tekmetric-app.labels" $ | nindent 4 }}
+  {{- with .annotations }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+type: Opaque
+stringData:
+  {{- $secret.data | toYaml | nindent 2 }}
+{{- end -}}
+{{- end -}}

--- a/platform/charts/tekmetric-app/templates/service-monitor.yaml
+++ b/platform/charts/tekmetric-app/templates/service-monitor.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "tekmetric-app.fullname" . }}
+  labels:
+    {{- include "tekmetric-app.labels" . | nindent 4 }}
+  {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "tekmetric-app.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: {{ required "A valid port NAME is required!" .Values.serviceMonitor.port }}
+      path: {{ .Values.serviceMonitor.path }}
+{{- end }}

--- a/platform/charts/tekmetric-app/templates/service.yaml
+++ b/platform/charts/tekmetric-app/templates/service.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.service.enabled .Values.service.port }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tekmetric-app.fullname" . }}
+  labels:
+    {{- include "tekmetric-app.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: {{ .Values.service.protocol | default "TCP" }}
+      name: {{ .Values.service.name }}
+  selector:
+    {{- include "tekmetric-app.selectorLabels" . | nindent 4 }}
+{{- end -}}

--- a/platform/charts/tekmetric-app/templates/serviceaccount.yaml
+++ b/platform/charts/tekmetric-app/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tekmetric-app.serviceAccountName" . }}
+  labels:
+    {{- include "tekmetric-app.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/platform/charts/tekmetric-app/values.yaml
+++ b/platform/charts/tekmetric-app/values.yaml
@@ -1,0 +1,224 @@
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+replicaCount: 1
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  repository: ghcr.io/ionutbalutoiu/tekmetric-interview
+  # This sets the pull policy for images.
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+
+# This is for setting up multiple "ConfigMap" resources that will be mounted into the app container via:
+#   * ".Values.app.envFrom" - for setting up environment variables.
+#   * ".Values.app.volumes" and ".Values.app.volumeMounts" - for mounting them as files.
+configMaps: {}
+  # myConfigMap:
+  #   name: "{{ .Release.Name }}-my-config-map"
+  #   data:
+  #     KEY: value
+  #     TEST_VAR: test-value
+  # secondConfigMap:
+  #   name: "{{ .Release.Name }}-second-config-map"
+  #   data:
+  #     SECOND_VAR: second-test-value
+  # configFiles:
+  #   name: "{{ .Release.Name }}-config-files"
+  #   data:
+  #     sample-config.yaml: |-
+  #       name: Sample Config File
+  #     versions.yaml: |-
+  #       version: 1.0.0
+
+# This is for setting up multiple "Secret" resources that will be mounted into the app container via:
+#   * ".Values.app.envFrom" - for setting up environment variables.
+#   * ".Values.app.volumes" and ".Values.app.volumeMounts" - for mounting them as files.
+secrets: {}
+  # mySecret:
+  #   name: "{{ .Release.Name }}-my-secret"
+  #   data:
+  #     DB_PASSWORD: super-secret-password
+  # mySecondSecret:
+  #   name: "{{ .Release.Name }}-my-second-secret"
+  #   data:
+  #     SECOND_SECRET: redacted
+  # sshKeys:
+  #   name: "{{ .Release.Name }}-ssh-keys"
+  #   data:
+  #     id_rsa: |
+  #       -----
+  #       REDACTED
+  #       -----
+  #     test_id_rsa: |
+  #       -----
+  #       TEST REDACTED
+  #       -----
+
+# Application configuration
+app:
+  # Override the default container image command.
+  command: []
+
+  # Override the default container image command arguments.
+  args: []
+
+  # This is setting up the environment variables for the app container from a configMap or secret.
+  envFrom: []
+    # - source: configMap                    # Valid values are: "configMap", "secret".
+    #   name: "{{ .Release.Name }}-env-vars" # The name of the configMap or secret.
+
+  # This is for setting up the app container ports. More information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+  ports:
+    - name: http
+      number: 80
+
+  # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  healthCheck:
+    # Define the readiness probe for the app container.
+    readinessProbe:
+      # Specifies whether the readiness probe should be enabled
+      enabled: true
+      # Defines the readiness probe spec.
+      spec:
+        httpGet:
+          path: /
+          port: http
+
+    # Define the liveness probe for the app container.
+    livenessProbe:
+      # Specifies whether the liveness probe should be enabled
+      enabled: true
+      # Defines the liveness probe spec.
+      spec:
+        httpGet:
+          path: /
+          port: http
+
+  # Additional volumes on the output Deployment definition.
+  volumes: []
+  # - name: foo
+  #   secret:
+  #     secretName: mysecret
+  #     optional: false
+
+  # Additional volumeMounts on the output Deployment definition.
+  volumeMounts: []
+  # - name: foo
+  #   mountPath: "/etc/foo"
+  #   readOnly: true
+
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+service:
+  # Specifies whether a service should be created.
+  enabled: true
+  # This sets the service type. More information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  type: ClusterIP
+  # This sets the service port name.
+  name: http
+  # This sets the service port protocol. More information can be found here: https://kubernetes.io/docs/reference/networking/service-protocols/
+  protocol: TCP
+  # This sets the service port number. More information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+  port: 80
+  # This sets the service target port. More information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+  targetPort: http
+
+# This section is used for setting up the Prometheus service monitor. More information can be found here: https://github.com/prometheus-operator/prometheus-operator/blob/v0.78.1/Documentation/user-guides/getting-started.md#using-servicemonitors
+serviceMonitor:
+  # Specifies whether a service monitor should be created.
+  enabled: false
+  # This adds extra service monitor labels besides the common ones.
+  labels: {}
+  # This sets the service monitor port. It must correspond to the port name of the service. This parameter is required.
+  port: http
+  # This sets the service monitor path.
+  path: /metrics
+
+# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+# This is for setting up the pod disruption budget more information can be found here: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
+pdb:
+  # Specifies whether a pod disruption budget should be created
+  enabled: false
+  # This sets the PDB maxUnavailable field.
+  maxUnavailable: 1
+  # This sets the PDB minAvailable field.
+  # minAvailable: 1
+
+# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/platform/helm_values/backend/production/secrets.yaml
+++ b/platform/helm_values/backend/production/secrets.yaml
@@ -1,0 +1,22 @@
+# NOTE: These are usually commited as SOPS (https://github.com/getsops/sops)
+# encrypted files. The idea is to have an encryption key that is shared with
+# the team and the CI/CD pipeline service account. Access to the key is
+# restricted to certain individuals. This way, the secrets are encrypted at
+# rest and only decrypted when needed.
+secrets:
+  env_vars:
+    name: "{{ .Release.Name }}-secrets"
+    data:
+      SECRET_KEY: production-sample-secret-value
+      DB_PASSWORD: production-sample-db-password
+  ssh_keys:
+    name: "{{ .Release.Name }}-ssh-keys"
+    data:
+      ci_id_rsa: |-
+        -----BEGIN RSA PRIVATE KEY
+        [production] CI id_rsa REDACTED
+        -----END RSA PRIVATE KEY
+      k8s_id_rsa: |-
+        -----BEGIN RSA PRIVATE KEY
+        [production] K8s id_rsa REDACTED
+        -----END RSA PRIVATE KEY

--- a/platform/helm_values/backend/production/values.yaml
+++ b/platform/helm_values/backend/production/values.yaml
@@ -1,0 +1,122 @@
+nameOverride: backend-production
+
+image:
+  repository: ghcr.io/ionutbalutoiu/tekmetric-interview-backend
+
+configMaps:
+  env_vars:
+    name: &envVarsCM "{{ .Release.Name }}-env-vars"
+    data:
+      ENV: production
+      TEST_VAR: production-test-value
+      SERVER_PORT: &portNumber "8095"
+  config_files:
+    name: &configFilesCM "{{ .Release.Name }}-config-files"
+    data:
+      sample-config.yaml: |-
+        app:
+          name: Production Tekmetric Interview Backend
+          environment: production
+
+app:
+  envFrom:
+    - source: configMap
+      name: *envVarsCM
+    - source: secret
+      name: "{{ .Release.Name }}-secrets"
+
+  ports:
+    - name: &portName http
+      number: *portNumber
+
+  healthCheck:
+    readinessProbe:
+      httpGet:
+        path: /api/health_check
+        port: *portName
+    livenessProbe:
+      httpGet:
+        path: /api/ping
+        port: *portName
+
+  volumes:
+    - name: config-files
+      configMap:
+        name: *configFilesCM
+    - name: ssh-keys
+      secret:
+        secretName: "{{ .Release.Name }}-ssh-keys"
+
+  volumeMounts:
+    - name: config-files
+      mountPath: /etc/config
+      readOnly: true
+    - name: ssh-keys
+      mountPath: /etc/ssh
+      readOnly: true
+
+service:
+  targetPort: *portName
+
+serviceMonitor:
+  enabled: true
+  labels:
+    release: kube-prometheus
+  port: *portName
+  path: /actuator/prometheus
+
+ingress:
+  enabled: true
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/router.tls.certresolver: le
+  hosts:
+    - host: tekmetric-interview-backend-production.balutoiu.com
+      paths:
+        - path: /
+          pathType: Exact
+        - path: /api
+          pathType: Prefix
+
+pdb:
+  enabled: true
+  maxUnavailable: 1
+
+autoscaling:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 6
+  targetCPUUtilizationPercentage: 80
+
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: node-pool
+              operator: In
+              values:
+                - k3s-workers
+  # NOTE: This ensures that app pods are spread across different Kubernetes workers in the cluster.
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/instance
+              operator: In
+              values:
+                - backend-production
+        topologyKey: kubernetes.io/hostname
+
+tolerations:
+  - key: spring-boot-apps
+    operator: Exists
+    effect: NoSchedule
+
+resources:
+  requests:
+    cpu: 0.1
+    memory: 512Mi
+  limits:
+    memory: 4Gi

--- a/platform/helm_values/backend/staging/secrets.yaml
+++ b/platform/helm_values/backend/staging/secrets.yaml
@@ -1,0 +1,22 @@
+# NOTE: These are usually commited as SOPS (https://github.com/getsops/sops)
+# encrypted files. The idea is to have an encryption key that is shared with
+# the team and the CI/CD pipeline service account. Access to the key is
+# restricted to certain individuals. This way, the secrets are encrypted at
+# rest and only decrypted when needed.
+secrets:
+  env_vars:
+    name: "{{ .Release.Name }}-secrets"
+    data:
+      SECRET_KEY: staging-sample-secret-value
+      DB_PASSWORD: staging-sample-db-password
+  ssh_keys:
+    name: "{{ .Release.Name }}-ssh-keys"
+    data:
+      ci_id_rsa: |-
+        -----BEGIN RSA PRIVATE KEY
+        [Staging] CI id_rsa REDACTED
+        -----END RSA PRIVATE KEY
+      k8s_id_rsa: |-
+        -----BEGIN RSA PRIVATE KEY
+        [Staging] K8s id_rsa REDACTED
+        -----END RSA PRIVATE KEY

--- a/platform/helm_values/backend/staging/values.yaml
+++ b/platform/helm_values/backend/staging/values.yaml
@@ -1,0 +1,114 @@
+nameOverride: backend-staging
+
+replicaCount: 2
+
+image:
+  repository: ghcr.io/ionutbalutoiu/tekmetric-interview-backend
+
+configMaps:
+  env_vars:
+    name: &envVarsCM "{{ .Release.Name }}-env-vars"
+    data:
+      ENV: staging
+      TEST_VAR: test-value
+      SERVER_PORT: &portNumber "8090"
+  config_files:
+    name: &configFilesCM "{{ .Release.Name }}-config-files"
+    data:
+      sample-config.yaml: |-
+        app:
+          name: Staging Tekmetric Interview Backend
+          environment: staging
+
+app:
+  envFrom:
+    - source: configMap
+      name: *envVarsCM
+    - source: secret
+      name: "{{ .Release.Name }}-secrets"
+
+  ports:
+    - name: &portName http
+      number: *portNumber
+
+  healthCheck:
+    readinessProbe:
+      httpGet:
+        path: /api/health_check
+        port: *portName
+    livenessProbe:
+      httpGet:
+        path: /api/ping
+        port: *portName
+
+  volumes:
+    - name: config-files
+      configMap:
+        name: *configFilesCM
+    - name: ssh-keys
+      secret:
+        secretName: "{{ .Release.Name }}-ssh-keys"
+
+  volumeMounts:
+    - name: config-files
+      mountPath: /etc/config
+      readOnly: true
+    - name: ssh-keys
+      mountPath: /etc/ssh
+      readOnly: true
+
+service:
+  targetPort: *portName
+
+serviceMonitor:
+  enabled: true
+  labels:
+    release: kube-prometheus
+  port: *portName
+  path: /actuator/prometheus
+
+ingress:
+  enabled: true
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/router.tls.certresolver: le
+  hosts:
+    - host: tekmetric-interview-backend-staging.balutoiu.com
+      paths:
+        - path: /
+          pathType: Exact
+        - path: /api
+          pathType: Prefix
+
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: node-pool
+              operator: In
+              values:
+                - k3s-workers
+  # NOTE: This ensures that app pods are spread across different Kubernetes workers in the cluster.
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/instance
+              operator: In
+              values:
+                - backend-staging
+        topologyKey: kubernetes.io/hostname
+
+tolerations:
+  - key: spring-boot-apps
+    operator: Exists
+    effect: NoSchedule
+
+resources:
+  requests:
+    cpu: 0.1
+    memory: 512Mi
+  limits:
+    memory: 4Gi

--- a/platform/scripts/deploy-helm-release.sh
+++ b/platform/scripts/deploy-helm-release.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -e
+set -o pipefail
+
+# Validate required environment variables
+if [[ -z "${HELM_NAMESPACE}" ]]; then
+    echo "ERROR: HELM_NAMESPACE environment variable is required"
+    exit 1
+fi
+if [[ -z "${HELM_RELEASE_NAME}" ]]; then
+    echo "ERROR: HELM_RELEASE_NAME environment variable is required"
+    exit 1
+fi
+
+# Add various options to the HELM_OPTS
+HELM_OPTS=${HELM_OPTS:-""}
+HELM_OPTS="${HELM_OPTS} --namespace=${HELM_NAMESPACE} --create-namespace"
+
+# Determine the chart to deploy (either from local or OCI)
+if [[ ! -z ${LOCAL_CHART_PATH} ]]; then
+    pushd ${LOCAL_CHART_PATH} >/dev/null
+    helm dep update
+    helm dep build
+    HELM_CHART="$(helm package . | cut -d ':' -f2 | awk '{print $1}')"
+    popd >/dev/null
+elif [[ ! -z ${HELM_OCI_CHART} ]]; then
+    HELM_CHART=${HELM_OCI_CHART}
+    if [[ -z ${HELM_OCI_CHART_VERSION} ]]; then
+        echo "ERROR: OCI chart (HELM_OCI_CHART env var) is specified, but chart version (HELM_OCI_CHART_VERSION env var) is not specified"
+        exit 1
+    fi
+    HELM_OPTS="${HELM_OPTS} --version ${HELM_OCI_CHART_VERSION}"
+else
+    echo "ERROR: No local chart path or OCI chart specified"
+    exit 1
+fi
+
+# Determine the Helm operation (install or upgrade)
+HELM_OP="install"
+if helm list -n ${HELM_NAMESPACE} | grep -q "^${HELM_RELEASE_NAME}"; then
+    # If the release already exists, upgrade it
+    HELM_OP="upgrade"
+fi
+
+# Deploy Helm release
+echo "Deploying Helm release ${HELM_RELEASE_NAME} in namespace ${HELM_NAMESPACE}"
+helm $HELM_OP $HELM_OPTS ${HELM_RELEASE_NAME} $HELM_CHART

--- a/platform/scripts/release-helm-charts.sh
+++ b/platform/scripts/release-helm-charts.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -e
+set -o pipefail
+
+# Validate required environment variables
+if [[ -z "$OCI_REGISTRY_URL" ]]; then
+    echo "OCI_REGISTRY_URL environment variable is not set"
+    exit 1
+fi
+if [[ -z "$OCI_REGISTRY_NAMESPACE" ]]; then
+    echo "OCI_REGISTRY_NAMESPACE environment variable is not set"
+    exit 1
+fi
+
+if [[ ! -z $OCI_REGISTRY_USER_NAME ]] && [[ ! -z $OCI_REGISTRY_USER_PASSWORD ]]; then
+    echo "Logging into OCI registry"
+    echo $OCI_REGISTRY_USER_PASSWORD | helm registry login $OCI_REGISTRY_URL --username $OCI_REGISTRY_USER_NAME --password-stdin
+fi
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHARTS_DIR="$(realpath "$DIR/../charts")"
+
+echo "Releasing local charts from $CHARTS_DIR to oci://${OCI_REGISTRY_URL}/${OCI_REGISTRY_NAMESPACE}/"
+
+for CHART_DIR in $(ls $CHARTS_DIR); do
+    echo "Releasing Helm chart: $CHART_DIR"
+    pushd "$CHARTS_DIR/$CHART_DIR" > /dev/null
+    helm dep update
+    helm dep build
+    CHART_PKG_PATH="$(helm package . | cut -d ':' -f2 | awk '{print $1}')"
+    helm push $CHART_PKG_PATH "oci://${OCI_REGISTRY_URL}/${OCI_REGISTRY_NAMESPACE}"
+done


### PR DESCRIPTION
This pull request submits the solution for the Tekmetric SRE home project.
A more detailed `README.md` is available [here](https://github.com/ionutbalutoiu/tekmetric-interview/tree/master/platform#platform-engineering-interview-home-project), in the forked repository. 

Below are the highlights of the proposed solution.

### Update and containerize the `backend` application

- Upgrade Java from `1.8` to `21` (latest LTS release).
- Upgrade Spring Boot to `3.3.5`.
- Add basic Sprint Boot Actuator configuration to gather app metrics, and enable monitoring via Prometheus.
- Add some basic health check endpoints:
  - `/api/health_check` - returns `200 OK` (used by Kubernetes readiness probe).
  - `/api/ping` - returns `200 OK` (used by Kubernetes liveness probe).
- Add basic `/` page handler that returns the hostname and address of the server.
- Add `Dockerfile` for backend app. It uses `amazoncorretto` with Java 21.

### Add `platform/charts/tekmetric-app` Helm chart

The purpose of this chart is to provide a base chart to deploy Tekmetric apps to Kubernetes. It is written in a way that it can be reused for other Tekmetric apps, and it allows setting up:

- `Deployment` resource, with configurable replicas, resources, and readiness/liveness probes, and other settings.
- `ConfigMap` / `Secret` resources, which can be consumed by the app deployment as environment variables or mounted as files.
- `Service` resource, with configurable parameters.
- `Ingress` resource, with configurable parameters.
- `ServiceAccount` resource, with configurable parameters.
- `HorizontalPodAutoscaler` resource, that scales the app based on CPU or RAM usage.
- `PodDisruptionBudget` resource, that ensures that a minimum number of pods are available during maintenance.
- `ServiceMonitor` resource, that scrapes metrics from the app and sends them to Prometheus.

### Add `platform/helm_values` directory with Helm values files

For now, it contains only Helm deployment configuration for `backend` app in `staging` and `production` environments.

### Add GHE Actions Workflows

- Build & push container image to `ghcr.io`.
- Deploy to Kubernetes in `staging`.
- Deploy to Kubernetes in `production`.
- Release Helm charts from `platform/charts` to `ghcr.io` (used as OCI registry).

### Add `platform/scripts` directory with helper scripts

These are used to:

- Deploy Helm release to Kubernetes.
- Release Helm charts to an OCI registry.
