### PR TITLE
Matthew Raspberry Senior SRE Submission

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -1,0 +1,18 @@
+name: Backend Service Deploy
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - backend
+
+jobs:
+  backend-ecs-deploy:
+    uses: ./.github/workflows/ecs-deploy.yml
+    with:
+      project-directory: backend
+      stack-name: backend-service
+      environment: prod
+    secrets: inherit
+      

--- a/.github/workflows/ecs-deploy.yml
+++ b/.github/workflows/ecs-deploy.yml
@@ -1,0 +1,75 @@
+name: ECS Deploy
+
+on:
+  workflow_call:
+    inputs:
+      project-directory:
+        type: string
+        description: directory containing the service to deploy
+        required: true
+      stack-name:
+        type: string
+        description: Cloudformation stack name
+        required: true
+      environment:
+        type: string
+        description: Environment to deploy to
+        required: true
+      aws-region:
+        type: string
+        description: Region to deploy to. Defaults to 'us-east-1'
+        required: false
+        default: us-east-1
+      ecr-repo-name:
+        type: string
+        description: Name of the ECR repo. Defaults to 'backend-infrastructure-repo'
+        required: false
+        default: backend-infrastructure-repo
+      template-file:
+        type: string
+        description: Name of the template file, relative to the project directory. Defaults to 'service.yaml'
+        required: false
+        default: service.yaml
+
+jobs:
+  deploy:
+    name: Build and Deploy to ECS
+    runs-on: ubuntu-latest
+    environment: ${{inputs.environment}}
+    defaults:
+      run:
+        working-directory: ${{inputs.project-directory}}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{vars.PIPELINE_EXECUTION_ROLE_ARN}}
+          aws-region: ${{inputs.aws-region}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and Push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ${{steps.login-ecr.outputs.registry}}/${{inputs.ecr-repo-name}}:${{github.sha}}
+          platforms: linux/amd64
+          context: ${{inputs.project-directory}}
+
+      - name: Deploy service
+        uses: aws-actions/aws-cloudformation-github-deploy@v1
+        with:
+          name: ${{inputs.stack-name}}
+          template: ${{inputs.project-directory}}/${{inputs.template-file}}
+          parameter-overrides: "ImageUri=${{steps.login-ecr.outputs.registry}}/${{inputs.ecr-repo-name}}:${{github.sha}},DomainName=${{vars.APP_DOMAIN}}"
+          capabilities: CAPABILITY_IAM
+          no-fail-on-empty-changeset: true
+          role-arn: ${{vars.CLOUDFORMATION_DEPLOY_ROLE}}

--- a/backend/.tool-versions
+++ b/backend/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-8.432.06.1

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,26 @@
+FROM public.ecr.aws/amazoncorretto/amazoncorretto:8-al2023-jre AS base
+
+ARG JAVA_OPTS=""
+ENV JAVA_OPTS="${JAVA_OPTS}"
+
+FROM public.ecr.aws/amazoncorretto/amazoncorretto:8-al2023-jdk AS builder
+
+WORKDIR /build
+
+COPY . ./
+
+RUN dnf install -y maven-amazon-corretto8 && \
+    mvn clean package
+
+FROM base AS final
+
+WORKDIR /app
+
+RUN adduser docker && chown docker:docker /app
+COPY --from=builder --chown=docker:docker /build/target/interview-1.0-SNAPSHOT.jar ./interview.jar
+
+USER docker
+
+EXPOSE 8080
+
+CMD ["java", "-jar", "interview.jar", "${JAVA_OPTS}"]

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -30,6 +30,10 @@
             <scope>runtime</scope>
             <version>2.1.210</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/backend/service.yaml
+++ b/backend/service.yaml
@@ -256,3 +256,26 @@ Resources:
         - "{{resolve:ssm:/shared/oncall-topic-arn}}"
       OKActions:
         - "{{resolve:ssm:/shared/oncall-topic-arn}}"
+
+  ServiceErrorsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${EcsService.Name}-service-errors"
+      AlarmDescription: "Service errors alarm for backend"
+      MetricName: HTTPCode_Target_5XX_Count
+      Namespace: AWS/ApplicationELB
+      Dimensions:
+        - Name: TargetGroup
+          Value: !Ref "TargetGroup"
+        - Name: LoadBalancer
+          Value: !ImportValue "backend-infrastructure:alb"
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 5
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - "{{resolve:ssm:/shared/oncall-topic-arn}}"
+      OKActions:
+        - "{{resolve:ssm:/shared/oncall-topic-arn}}"

--- a/backend/service.yaml
+++ b/backend/service.yaml
@@ -1,0 +1,258 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Deploys the ECS service and related infrastructure for the backend application
+
+Parameters:
+  ImageUri:
+    Type: String
+    Description: URI for the backend image to deploy
+  DomainName:
+    Type: String
+    Description: The domain name for the backend service
+  TaskCpu:
+    Type: "Number"
+    Description: CPU size for the tasks
+    Default: 1024
+  TaskMemory:
+    Type: "Number"
+    Description: Memory size for the tasks
+    Default: 2048
+
+Resources:
+  TargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      VpcId: !ImportValue "backend-infrastructure:vpc"
+      Port: 8080
+      Protocol: HTTP
+      Matcher:
+        HttpCode: 200-299
+      HealthCheckIntervalSeconds: 15
+      HealthCheckPath: /actuator/health
+      HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 2
+      TargetType: ip
+
+  ListenerRule:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    Properties:
+      ListenerArn: !ImportValue "backend-infrastructure:https-alb-listener"
+      Priority: 1
+      Conditions:
+        - Field: host-header
+          Values:
+            - !Ref DomainName
+      Actions:
+        - TargetGroupArn: !Ref TargetGroup
+          Type: forward
+
+  EcsTaskExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: "ecs-tasks.amazonaws.com"
+            Action: "sts:AssumeRole"
+      Policies:
+        - PolicyName: "EcsTaskExecutionPolicy"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "logs:CreateLogStream"
+                  - "logs:PutLogEvents"
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - "ecr:GetAuthorizationToken"
+                  - "ecr:BatchCheckLayerAvailability"
+                  - "ecr:GetDownloadUrlForLayer"
+                  - "ecr:BatchGetImage"
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - "ssm:GetParameter*"
+                Resource:
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/backend/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/shared/*"
+
+  EcsTaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: "ecs-tasks.amazonaws.com"
+            Action: "sts:AssumeRole"
+
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: "backend"
+      TaskRoleArn: !Ref "EcsTaskRole"
+      ExecutionRoleArn: !Ref "EcsTaskExecutionRole"
+      NetworkMode: "awsvpc"
+      RequiresCompatibilities:
+        - "FARGATE"
+      Cpu: !Ref TaskCpu
+      Memory: !Ref TaskMemory
+      ContainerDefinitions:
+        - Name: "backend"
+          Image: !Ref "ImageUri"
+          Environment:
+            - Name: "SPRING_PROFILES_ACTIVE"
+              Value: "production"
+          PortMappings:
+            - ContainerPort: 8080
+          LogConfiguration:
+            LogDriver: "awslogs"
+            Options:
+              "awslogs-group": !Ref EcsLogGroup
+              "awslogs-region": !Ref AWS::Region
+              "awslogs-stream-prefix": "backend"
+
+  EcsService:
+    Type: AWS::ECS::Service
+    DependsOn: ListenerRule
+    Properties:
+      Cluster: !ImportValue "backend-infrastructure:cluster"
+      LaunchType: "FARGATE"
+      ServiceName: "backend"
+      DesiredCount: 1
+      TaskDefinition: !Ref TaskDefinition
+      PlatformVersion: LATEST
+      HealthCheckGracePeriodSeconds: 30
+      DeploymentConfiguration:
+        MinimumHealthyPercent: 100
+        MaximumPercent: 200
+      PropagateTags: "SERVICE"
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: "DISABLED"
+          SecurityGroups:
+            - !ImportValue "backend-infrastructure:ecs-sg"
+          Subnets:
+            !Split [",", !ImportValue "backend-infrastructure:app-subnets"]
+      LoadBalancers:
+        - ContainerName: "backend"
+          ContainerPort: 8080
+          TargetGroupArn: !Ref "TargetGroup"
+
+  EcsLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: "/aws/ecs/backend"
+      RetentionInDays: 365
+
+  ScalableTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    Properties:
+      ResourceId:
+        !Join [
+          "/",
+          [
+            service,
+            !ImportValue "backend-infrastructure:cluster",
+            !GetAtt EcsService.Name,
+          ],
+        ]
+      ServiceNamespace: ecs
+      ScalableDimension: ecs:service:DesiredCount
+      MinCapacity: 3
+      MaxCapacity: 100
+
+  ScaleOutPolicy:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: CPUServiceScaleOutPolicy
+      PolicyType: StepScaling
+      ScalingTargetId: !Ref ScalableTarget
+      StepScalingPolicyConfiguration:
+        AdjustmentType: ChangeInCapacity
+        StepAdjustments:
+          - MetricIntervalLowerBound: 0
+            ScalingAdjustment: 2
+
+  ScaleInPolicy:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: CPUServiceScaleInPolicy
+      PolicyType: StepScaling
+      ScalingTargetId: !Ref ScalableTarget
+      StepScalingPolicyConfiguration:
+        AdjustmentType: ChangeInCapacity
+        Cooldown: 600 # scale down slower than we scaled up
+        StepAdjustments:
+          - MetricIntervalUpperBound: 0
+            ScalingAdjustment: -1
+
+  CpuAlarmScaleOut:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub ${EcsService.Name}-cpu-scale-out
+      AlarmDescription: "High CPU Scale Out alarm for API"
+      MetricName: CPUUtilization
+      Namespace: AWS/ECS
+      Dimensions:
+        - Name: ServiceName
+          Value: !GetAtt EcsService.Name
+        - Name: ClusterName
+          Value: !ImportValue "backend-infrastructure:cluster"
+      Statistic: Average
+      Period: 60
+      EvaluationPeriods: 3
+      Threshold: 60
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmActions:
+        - !Ref ScaleOutPolicy
+
+  CpuAlarmScaleIn:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub ${EcsService.Name}-cpu-scale-in
+      AlarmDescription: !Sub "Low CPU Scale In alarm for ${EcsService.Name}"
+      MetricName: CPUUtilization
+      Namespace: AWS/ECS
+      Dimensions:
+        - Name: ServiceName
+          Value: !GetAtt EcsService.Name
+        - Name: ClusterName
+          Value: !ImportValue "backend-infrastructure:cluster"
+      Statistic: Average
+      Period: 300
+      EvaluationPeriods: 2
+      Threshold: 40
+      ComparisonOperator: LessThanOrEqualToThreshold
+      AlarmActions:
+        - !Ref ScaleInPolicy
+
+  NoHealthyHostsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${EcsService.Name}-no-healthy-hosts"
+      AlarmDescription: "No healthy hosts alarm for backend"
+      MetricName: UnHealthyHostCount
+      Namespace: AWS/ApplicationELB
+      Dimensions:
+        - Name: TargetGroup
+          Value: !Ref "TargetGroup"
+        - Name: LoadBalancer
+          Value: !ImportValue "backend-infrastructure:alb"
+      Statistic: Average
+      Period: 60
+      EvaluationPeriods: 2
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: breaching
+      AlarmActions:
+        - "{{resolve:ssm:/shared/oncall-topic-arn}}"
+      OKActions:
+        - "{{resolve:ssm:/shared/oncall-topic-arn}}"

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -4,3 +4,4 @@ spring.datasource.username=sa
 spring.datasource.password=password
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.h2.console.enabled=true
+management.endpoints.web.exposure.include=health

--- a/platform/infrastructure.yaml
+++ b/platform/infrastructure.yaml
@@ -1,0 +1,503 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Deploys the routing layer for the backend services
+
+Parameters:
+  DomainName:
+    Type: String
+    Description: The domain name to use for the application
+
+  CertificateArn:
+    Type: String
+    Description: The certificate to use for the application
+
+  HostedZoneId:
+    Type: String
+    Description: The hosted zone to use for the application
+
+Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/20
+      EnableDnsHostnames: true
+      Tags:
+        - Key: Name
+          Value: !Ref AWS::StackName
+
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-igw"
+
+  InternetGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      InternetGatewayId: !Ref InternetGateway
+      VpcId: !Ref VPC
+
+  # setup the CIDRs this way to make any future
+  # routes or firewall rules easier to write
+  # The full space is 10.0.0.0/20
+  #
+  # The public subnets (for the alb) are the first 3 /23s
+  # that make up 10.0.0.0/21, with the 4th held in reserve for future expansion
+  # Any firewall rules or routes that need to reference all the public
+  # subnets can be condensed to just 10.0.0.0/21
+  #
+  # The private subnets (for the app) are the first 3 /24s
+  # that make up 10.0.8.0/21, with the 4th held in reserve for future expansion
+  # Any firewall rules or routes that need to reference all the private
+  # subnets can be condensed to just 10.0.8.0/21
+  AlbSubnet1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      CidrBlock: 10.0.0.0/23
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-alb-az1"
+
+  AlbSubnet2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      AvailabilityZone: !Select [1, !GetAZs ""]
+      CidrBlock: 10.0.2.0/23
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-alb-az2"
+
+  AlbSubnet3:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      AvailabilityZone: !Select [2, !GetAZs ""]
+      CidrBlock: 10.0.4.0/23
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-alb-az3"
+
+  AppSubnet1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      CidrBlock: 10.0.8.0/23
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-app-az1"
+
+  AppSubnet2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      AvailabilityZone: !Select [1, !GetAZs ""]
+      CidrBlock: 10.0.10.0/23
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-app-az2"
+
+  AppSubnet3:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      AvailabilityZone: !Select [2, !GetAZs ""]
+      CidrBlock: 10.0.12.0/23
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-app-az3"
+
+  NatGateway1EIP:
+    Type: AWS::EC2::EIP
+    DependsOn: InternetGatewayAttachment
+    Properties:
+      Domain: vpc
+
+  NatGateway2EIP:
+    Type: AWS::EC2::EIP
+    DependsOn: InternetGatewayAttachment
+    Properties:
+      Domain: vpc
+
+  NatGateway3EIP:
+    Type: AWS::EC2::EIP
+    DependsOn: InternetGatewayAttachment
+    Properties:
+      Domain: vpc
+
+  NatGateway1:
+    Type: AWS::EC2::NatGateway
+    Properties:
+      AllocationId: !GetAtt NatGateway1EIP.AllocationId
+      SubnetId: !Ref AlbSubnet1
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-natgw-az1"
+
+  NatGateway2:
+    Type: AWS::EC2::NatGateway
+    Properties:
+      AllocationId: !GetAtt NatGateway2EIP.AllocationId
+      SubnetId: !Ref AlbSubnet2
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-natgw-az2"
+
+  NatGateway3:
+    Type: AWS::EC2::NatGateway
+    Properties:
+      AllocationId: !GetAtt NatGateway3EIP.AllocationId
+      SubnetId: !Ref AlbSubnet3
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-natgw-az3"
+
+  AlbRouteTable1:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+
+  AlbRouteToInternet1:
+    Type: AWS::EC2::Route
+    Properties:
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+      RouteTableId: !Ref AlbRouteTable1
+
+  AlbRouteTable2:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+
+  AlbRouteToInternet2:
+    Type: AWS::EC2::Route
+    Properties:
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+      RouteTableId: !Ref AlbRouteTable2
+
+  AlbRouteTable3:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+
+  AlbRouteToInternet3:
+    Type: AWS::EC2::Route
+    Properties:
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+      RouteTableId: !Ref AlbRouteTable3
+
+  AlbSubnet1RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref AlbRouteTable1
+      SubnetId: !Ref AlbSubnet1
+
+  AlbSubnet2RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref AlbRouteTable2
+      SubnetId: !Ref AlbSubnet2
+
+  AlbSubnet3RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref AlbRouteTable3
+      SubnetId: !Ref AlbSubnet3
+
+  AppRouteTable1:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+
+  DefaultAppRoute1:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref AppRouteTable1
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId: !Ref NatGateway1
+
+  AppSubnet1RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref AppRouteTable1
+      SubnetId: !Ref AppSubnet1
+
+  AppRouteTable2:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+
+  DefaultAppRoute2:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref AppRouteTable2
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId: !Ref NatGateway2
+
+  AppSubnet2RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref AppRouteTable2
+      SubnetId: !Ref AppSubnet2
+
+  AppRouteTable3:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+
+  DefaultAppRoute3:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref AppRouteTable3
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId: !Ref NatGateway3
+
+  AppSubnet3RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref AppRouteTable3
+      SubnetId: !Ref AppSubnet3
+
+  EcsCluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: !Sub ${AWS::StackName}-cluster
+      ClusterSettings:
+        - Name: containerInsights
+          Value: enabled
+      CapacityProviders:
+        - FARGATE
+      DefaultCapacityProviderStrategy:
+        - CapacityProvider: FARGATE
+
+  AlbSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: !Sub ${AWS::StackName}-alb-sg
+      GroupDescription: Security group for the ALB
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+      SecurityGroupEgress:
+        - IpProtocol: -1
+          CidrIp: 0.0.0.0/0
+
+  EcsServiceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: !Sub ${AWS::StackName}-ecs-sg
+      GroupDescription: Security group for the ECS service
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 8080
+          ToPort: 8080
+          SourceSecurityGroupId: !Ref AlbSecurityGroup
+      SecurityGroupEgress:
+        - IpProtocol: -1
+          CidrIp: 0.0.0.0/0
+
+  Alb:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: !Sub "${AWS::StackName}-alb"
+      Type: application
+      Scheme: internet-facing
+      Subnets:
+        - !Ref AlbSubnet1
+        - !Ref AlbSubnet2
+        - !Ref AlbSubnet3
+      SecurityGroups:
+        - !Ref AlbSecurityGroup
+
+  AlbHttpsListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref Alb
+      Port: 443
+      Protocol: HTTPS
+      DefaultActions:
+        - Type: fixed-response
+          FixedResponseConfig:
+            ContentType: text/plain
+            MessageBody: "Not Found"
+            StatusCode: "404"
+      Certificates:
+        - CertificateArn: !Ref CertificateArn
+
+  AlbCachePolicy:
+    Type: AWS::CloudFront::CachePolicy
+    Properties:
+      CachePolicyConfig:
+        DefaultTTL: 0 # rely on the services to set Cache-Control
+        MaxTTL: 604800 # 7 days
+        MinTTL: 0
+        Name: !Sub "${AWS::StackName}-cache-policy"
+        ParametersInCacheKeyAndForwardedToOrigin:
+          CookiesConfig:
+            CookieBehavior: none
+          HeadersConfig:
+            HeaderBehavior: whitelist
+            Headers:
+              - Authorization
+              - Origin
+          QueryStringsConfig:
+            QueryStringBehavior: all
+          EnableAcceptEncodingGzip: true
+          EnableAcceptEncodingBrotli: true
+
+  CloudfrontDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Enabled: true
+        HttpVersion: http2and3
+        Comment: Backend services
+        Aliases:
+          - !Ref DomainName
+        DefaultCacheBehavior:
+          CachePolicyId: !Ref AlbCachePolicy
+          OriginRequestPolicyId: 216adef6-5c7f-47e4-b989-5492eafa07d3 # Managed-AllViewer
+          ResponseHeadersPolicyId: 5cc3b908-e619-4b99-88e5-2cf7f45965bd # Managed-CORS-With-Preflight
+          AllowedMethods:
+            - GET
+            - HEAD
+            - OPTIONS
+            - PUT
+            - POST
+            - PATCH
+            - DELETE
+          CachedMethods:
+            - GET
+            - HEAD
+            - OPTIONS
+          Compress: true
+          TargetOriginId: alb
+          ViewerProtocolPolicy: redirect-to-https
+        Origins:
+          - Id: alb
+            DomainName: !GetAtt Alb.DNSName
+            CustomOriginConfig:
+              HTTPPort: 80
+              HTTPSPort: 443
+              OriginProtocolPolicy: https-only
+              OriginSSLProtocols:
+                - TLSv1.2
+            OriginCustomHeaders:
+              - HeaderName: "{{resolve:secretsmanager:/shared/cloudfront-alb-header:SecretString:headerName}}"
+                HeaderValue: "{{resolve:secretsmanager:/shared/cloudfront-alb-header:SecretString:headerValue}}"
+        ViewerCertificate:
+          AcmCertificateArn: !Ref CertificateArn
+          SslSupportMethod: sni-only
+          MinimumProtocolVersion: TLSv1.2_2021
+
+  DnsARecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      Type: A
+      HostedZoneId: !Ref HostedZoneId
+      Name: !Ref DomainName
+      AliasTarget:
+        DNSName: !GetAtt CloudfrontDistribution.DomainName
+        HostedZoneId: Z2FDTNDATAQYW2 # cloudfront hosted zone id
+
+  DnsAAAARecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      Type: AAAA
+      HostedZoneId: !Ref HostedZoneId
+      Name: !Ref DomainName
+      AliasTarget:
+        DNSName: !GetAtt CloudfrontDistribution.DomainName
+        HostedZoneId: Z2FDTNDATAQYW2 # cloudfront hosted zone id
+
+  Ecr:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: !Sub "${AWS::StackName}-repo"
+      ImageTagMutability: MUTABLE
+      EmptyOnDelete: true
+      ImageScanningConfiguration:
+        ScanOnPush: true
+
+Outputs:
+  Vpc:
+    Description: VPC Id for the VPC
+    Value: !Ref VPC
+    Export:
+      Name: !Sub "${AWS::StackName}:vpc"
+
+  AppSubnet1:
+    Description: App subnet 1
+    Value: !Ref AppSubnet1
+    Export:
+      Name: !Sub "${AWS::StackName}:app-subnet-1"
+
+  AppSubnet2:
+    Description: App subnet 2
+    Value: !Ref AppSubnet2
+    Export:
+      Name: !Sub "${AWS::StackName}:app-subnet-2"
+
+  AppSubnet3:
+    Description: App subnet 3
+    Value: !Ref AppSubnet3
+    Export:
+      Name: !Sub "${AWS::StackName}:app-subnet-3"
+
+  AppSubnetList:
+    Description: Comma separated list of app subnets
+    Value: !Join [",", [!Ref AppSubnet1, !Ref AppSubnet2, !Ref AppSubnet3]]
+    Export:
+      Name: !Sub "${AWS::StackName}:app-subnets"
+
+  EcsServiceSecurityGroup:
+    Description: ECS service security group
+    Value: !Ref EcsServiceSecurityGroup
+    Export:
+      Name: !Sub "${AWS::StackName}:ecs-sg"
+
+  EcsCluster:
+    Description: ECS Cluster for the backend services
+    Value: !Ref EcsCluster
+    Export:
+      Name: !Sub "${AWS::StackName}:cluster"
+
+  Alb:
+    Description: Application load balancer
+    Value: !Ref Alb
+    Export:
+      Name: !Sub "${AWS::StackName}:alb"
+
+  HttpsListenerArn:
+    Description: Listener ARN for the ALB
+    Value: !Ref AlbHttpsListener
+    Export:
+      Name: !Sub "${AWS::StackName}:https-alb-listener"
+
+  EcrRepoArn:
+    Description: ECR repository ARN
+    Value: !GetAtt Ecr.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}:ecr-repo-arn"
+
+  EcrRepoUri:
+    Description: ECR repository URI
+    Value: !GetAtt Ecr.RepositoryUri
+    Export:
+      Name: !Sub "${AWS::StackName}:ecr-repo-uri"


### PR DESCRIPTION
## Summary

Productionized backend service. Creates the following infrastructure:

- VPC with one /20 divided across 3 AZs with 3 private and 3 public subnets, each a /23
- Application Load Balancer for the services to use with a default response of returning a 404
- Cloudfront distribution pointing to the ALB. It also sends a custom header to the origin to enforce that the services must be accessed through CloudFront
- ECS service for the backend application connected to the ALB
- Example Github Actions workflow to deploy the ECS service

## Assumptions
This has been built with the following assumptions:

1. The backend in this example is a monolith. If it were a microservice I would recommend using path-based routing on the ALB instead of host-based routing. This would be particularly useful if application teams have the ability to manage their own service infrastructure as no DNS changes would be required to add a new service
2. The routing layer is not automatically deployed in a CI/CD fashion as it has a large blast radius
3. The routing layer is ok to be built in the same account as the ECS services. An alternative implementation in a multi-account architecture would be to use a dedicated account for the network and share it to workload accounts using AWS Resource Access Manager (RAM)
4. The scaling strategy has been built assuming the application is CPU intensive, not memory intensive