### PR TITLE
UI and API test for account creation,  Playwright automation exercise

### DIFF
--- a/qa/tests/api/createUser.spec.ts
+++ b/qa/tests/api/createUser.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect, request } from '@playwright/test';
+
+//documentation: https://www.automationexercise.com/api_list
+test('Create user via API with valid data', async () => {
+    const requestContext = await request.newContext();
+
+    const uniqueEmail = `apitestuser_${Date.now()}@example.com`;
+
+    const response = await requestContext.post('https://automationexercise.com/api/createAccount', {
+        form: {
+            name: 'Test User',
+            email: uniqueEmail,
+            password: 'StrongPass123!',
+            title: 'Mr',
+            birth_date: '1',
+            birth_month: '1',
+            birth_year: '1995',
+            firstname: 'Test',
+            lastname: 'User',
+            company: 'QA company',
+            address1: '123 Test St',
+            address2: 'Suite 555',
+            country: 'United States',
+            zipcode: '12345',
+            state: 'WI',
+            city: 'Middleton',
+            mobile_number: '1234567890'
+        }
+    });
+
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    console.log('API response:', body);
+
+    expect(body.responseCode).toBe(201);
+    expect(body.message).toContain('User created!');
+});

--- a/qa/tests/ui/create-account.spec.ts
+++ b/qa/tests/ui/create-account.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+test('New user can create an account with valid data', async ({ page }) => {
+    await page.goto('https://www.automationexercise.com/login');
+
+    await expect(page.getByText('New User Signup!')).toBeVisible();
+
+    const uniqueEmail = `testuser_${Date.now()}@example.com`;
+
+    await page.locator('[data-qa="signup-name"]').fill('Test User');
+    await page.locator('[data-qa="signup-email"]').fill(uniqueEmail);
+    await page.locator('[data-qa="signup-button"]').click();
+
+    await expect(page.getByText('Enter Account Information')).toBeVisible();
+
+    await page.locator('#id_gender1').check();
+    await page.locator('#password').fill('StrongPassword987!');
+
+    await page.locator('#days').selectOption('1');
+    await page.locator('#months').selectOption('1');
+    await page.locator('#years').selectOption('1995');
+
+    await page.getByLabel('Sign up for our newsletter!').check();
+    await page.getByLabel('Receive special offers from our partners!').check();
+
+    await page.locator('#first_name').fill('FirstUser');
+    await page.locator('#last_name').fill('LastUser');
+    await page.locator('#company').fill('testerCompany');
+    await page.locator('#address1').fill('111 testBuilding');
+
+    await page.locator('#country').selectOption({ label: 'United States' });
+
+    await page.locator('#state').fill('WI');
+    await page.locator('#city').fill('Middleton');
+    await page.locator('#zipcode').fill('222333');
+    await page.locator('#mobile_number').fill('1112223344');
+
+    await page.locator('[data-qa="create-account"]').click();
+
+    await expect(page.getByText('Account Created!')).toBeVisible();
+
+});


### PR DESCRIPTION
Hi Team,

This PR includes: 
• UI automation for account creation using Playwright 
• API test for user creation via /createAccount
The remaining items from the exercise are not included due to time constraints. I focused on delivering a clean and working implementation of the core flows.
Thanks for the opportunity!