### PR TITLE
Part and Work Order Management

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -42,10 +42,29 @@
             <artifactId>jackson-databind</artifactId>
             <version>3.0.1</version>
         </dependency>
+
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <properties>
         <java.version>21</java.version>
+        <assertj.version>3.27.3</assertj.version>
     </properties>
 
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.1.RELEASE</version>
+        <version>3.5.7</version>
     </parent>
 
     <dependencies>
@@ -22,18 +22,30 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
-            <version>2.1.4.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>runtime</scope>
-            <version>2.1.210</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.42</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/tools.jackson.core/jackson-databind -->
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>3.0.1</version>
         </dependency>
     </dependencies>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>21</java.version>
     </properties>
 
 

--- a/backend/src/main/java/com/interview/controller/PartController.java
+++ b/backend/src/main/java/com/interview/controller/PartController.java
@@ -1,0 +1,46 @@
+package com.interview.controller;
+
+import com.interview.exception.ResourceNotFoundException;
+import com.interview.model.Part;
+import com.interview.service.PartService;
+import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@AllArgsConstructor
+public class PartController {
+    private final PartService partService;
+
+    @GetMapping("/api/part/{partId}")
+    public Part getPart(@PathVariable Long partId) {
+        return partService.get(partId)
+                .orElseThrow(() -> new ResourceNotFoundException("No part found with id: " + partId));
+    }
+
+    @GetMapping("/api/parts")
+    public Page<Part> getAllParts(Pageable pageable) {
+        return partService.getAll(pageable);
+    }
+
+    @PostMapping("/api/part")
+    public Part addPart(@RequestBody Part part) {
+        return partService.create(part);
+    }
+
+    @PutMapping("/api/part/{partId}")
+    public Part updatePart(@PathVariable Long partId, @RequestBody Part part) {
+        return partService.update(part.setId(partId));
+    }
+
+    @PostMapping("/api/part/{partId}/inventory")
+    public Part updateInventory(@PathVariable Long partId, @RequestParam int inventoryDelta) {
+        return partService.adjustInventory(partId, inventoryDelta);
+    }
+
+    @DeleteMapping("/api/part/{partId}")
+    public void deletePart(@PathVariable Long partId) {
+        partService.delete(partId);
+    }
+}

--- a/backend/src/main/java/com/interview/controller/WorkOrderController.java
+++ b/backend/src/main/java/com/interview/controller/WorkOrderController.java
@@ -1,0 +1,41 @@
+package com.interview.controller;
+
+import com.interview.exception.ResourceNotFoundException;
+import com.interview.model.WorkOrder;
+import com.interview.service.WorkOrderService;
+import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@AllArgsConstructor
+public class WorkOrderController {
+    private final WorkOrderService workOrderService;
+
+    @GetMapping("/api/workOrder/{workOrderId}")
+    public WorkOrder getWorkOrder(@PathVariable Long workOrderId) {
+        return workOrderService.get(workOrderId)
+                .orElseThrow(() -> new ResourceNotFoundException("No work order found with id: " + workOrderId));
+    }
+
+    @GetMapping("/api/workOrders")
+    public Page<WorkOrder> getAllWorkOrders(Pageable pageable) {
+        return workOrderService.getAll(pageable);
+    }
+
+    @PostMapping("/api/workOrder")
+    public WorkOrder createWorkOrder(@RequestBody WorkOrder workOrder) {
+        return workOrderService.create(workOrder);
+    }
+
+    @PutMapping("/api/workOrder/{workOrderId}")
+    public WorkOrder updateWorkOrder(@PathVariable Long workOrderId, @RequestBody WorkOrder workOrder) {
+        return workOrderService.update(workOrder.setId(workOrderId));
+    }
+
+    @DeleteMapping("/api/workOrder/{workOrderId}")
+    public void deleteWorkOrder(@PathVariable Long workOrderId) {
+        workOrderService.delete(workOrderId);
+    }
+}

--- a/backend/src/main/java/com/interview/entity/PartEntity.java
+++ b/backend/src/main/java/com/interview/entity/PartEntity.java
@@ -12,11 +12,12 @@ import lombok.experimental.Accessors;
 @Accessors(chain = true)
 public class PartEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;
 
     @Setter(AccessLevel.NONE)
     @Column(nullable = false)
-    private int inventory = 0;}
+    private int inventory;
+}

--- a/backend/src/main/java/com/interview/entity/PartEntity.java
+++ b/backend/src/main/java/com/interview/entity/PartEntity.java
@@ -1,0 +1,22 @@
+package com.interview.entity;
+
+import jakarta.persistence.*;
+
+import lombok.*;
+import lombok.experimental.Accessors;
+
+@Entity
+@Table(name = "parts")
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor
+@Accessors(chain = true)
+public class PartEntity {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String name;
+
+    @Setter(AccessLevel.NONE)
+    @Column(nullable = false)
+    private int inventory = 0;}

--- a/backend/src/main/java/com/interview/entity/WorkOrderEntity.java
+++ b/backend/src/main/java/com/interview/entity/WorkOrderEntity.java
@@ -15,7 +15,7 @@ import lombok.experimental.Accessors;
 @Accessors(chain = true)
 public class WorkOrderEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @OneToMany(mappedBy = "workOrder", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/backend/src/main/java/com/interview/entity/WorkOrderEntity.java
+++ b/backend/src/main/java/com/interview/entity/WorkOrderEntity.java
@@ -1,0 +1,23 @@
+package com.interview.entity;
+
+import jakarta.persistence.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.*;
+import lombok.experimental.Accessors;
+
+@Entity
+@Table(name = "work_orders")
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor
+@Accessors(chain = true)
+public class WorkOrderEntity {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @OneToMany(mappedBy = "workOrder", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<WorkOrderPartEntity> parts = new ArrayList<>();
+}

--- a/backend/src/main/java/com/interview/entity/WorkOrderPartEntity.java
+++ b/backend/src/main/java/com/interview/entity/WorkOrderPartEntity.java
@@ -14,7 +14,7 @@ import lombok.experimental.Accessors;
 @Accessors(chain = true)
 public class WorkOrderPartEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/backend/src/main/java/com/interview/entity/WorkOrderPartEntity.java
+++ b/backend/src/main/java/com/interview/entity/WorkOrderPartEntity.java
@@ -1,0 +1,30 @@
+package com.interview.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.Accessors;
+
+@Entity
+@Table(
+        name = "work_order_parts",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"work_order_id","part_id"})
+)
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor
+@Accessors(chain = true)
+public class WorkOrderPartEntity {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "work_order_id", nullable = false)
+    private WorkOrderEntity workOrder;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "part_id", nullable = false)
+    private PartEntity part;
+
+    @Column(nullable = false)
+    private int partCount = 0;
+}

--- a/backend/src/main/java/com/interview/exception/BadRequestException.java
+++ b/backend/src/main/java/com/interview/exception/BadRequestException.java
@@ -1,0 +1,11 @@
+package com.interview.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/interview/exception/ResourceNotFoundException.java
+++ b/backend/src/main/java/com/interview/exception/ResourceNotFoundException.java
@@ -1,0 +1,11 @@
+package com.interview.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/interview/model/Part.java
+++ b/backend/src/main/java/com/interview/model/Part.java
@@ -1,0 +1,30 @@
+package com.interview.model;
+
+import com.interview.entity.PartEntity;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+import lombok.experimental.Accessors;
+
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor
+@Accessors(chain = true)
+public class Part {
+    private Long id;
+    private String name;
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    private int inventory;
+
+    public static Part fromEntity(PartEntity entity) {
+        if (entity == null) return null;
+        return new Part()
+                .setId(entity.getId())
+                .setName(entity.getName())
+                .setInventory(entity.getInventory());
+    }
+
+    public PartEntity toEntity() {
+        return new PartEntity()
+                .setId(this.id)
+                .setName(this.name);
+    }
+}

--- a/backend/src/main/java/com/interview/model/PartRequirement.java
+++ b/backend/src/main/java/com/interview/model/PartRequirement.java
@@ -1,0 +1,12 @@
+package com.interview.model;
+
+import lombok.*;
+import lombok.experimental.Accessors;
+
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor
+@Accessors(chain = true)
+public class PartRequirement {
+    private Long partId;
+    private int requiredCount;
+}

--- a/backend/src/main/java/com/interview/model/WorkOrder.java
+++ b/backend/src/main/java/com/interview/model/WorkOrder.java
@@ -60,7 +60,7 @@ public class WorkOrder {
         return model;
     }
 
-    private static boolean isReadyToStart(WorkOrderEntity workOrder) {
+    protected static boolean isReadyToStart(WorkOrderEntity workOrder) {
         // Work order is "ready to start" if there is sufficient inventory for all required parts
         return workOrder.getParts().stream()
                 .allMatch(wop -> wop.getPart().getInventory() >= wop.getPartCount());

--- a/backend/src/main/java/com/interview/model/WorkOrder.java
+++ b/backend/src/main/java/com/interview/model/WorkOrder.java
@@ -1,0 +1,68 @@
+package com.interview.model;
+
+import com.interview.entity.WorkOrderEntity;
+import com.interview.entity.WorkOrderPartEntity;
+import com.interview.entity.PartEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import java.util.List;
+import java.util.ArrayList;
+
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor
+@Accessors(chain = true)
+public class WorkOrder {
+    private Long id;
+    private List<PartRequirement> partRequirements;
+    private boolean readyToStart;
+
+    public WorkOrderEntity toEntity() {
+        WorkOrderEntity entity = new WorkOrderEntity();
+        entity.setId(this.id);
+
+        if (this.partRequirements != null && !this.partRequirements.isEmpty()) {
+            List<WorkOrderPartEntity> workOrderParts = new ArrayList<>();
+            for (PartRequirement partRequirement : this.partRequirements) {
+                WorkOrderPartEntity wop = new WorkOrderPartEntity()
+                        .setWorkOrder(entity)
+                        .setPart(new PartEntity().setId(partRequirement.getPartId()))
+                        .setPartCount(partRequirement.getRequiredCount());
+
+                workOrderParts.add(wop);
+            }
+            entity.setParts(workOrderParts);
+        } else {
+            entity.setParts(new ArrayList<>());
+        }
+        return entity;
+    }
+
+    public static WorkOrder fromEntity(WorkOrderEntity entity) {
+        WorkOrder model = new WorkOrder()
+                .setId(entity.getId())
+                .setReadyToStart(isReadyToStart(entity));
+
+        if (entity.getParts() != null && !entity.getParts().isEmpty()) {
+            List<PartRequirement> partRequirements = new ArrayList<>();
+            for (WorkOrderPartEntity wop : entity.getParts()) {
+                PartRequirement partRequirement = new PartRequirement()
+                        .setPartId(wop.getPart().getId())
+                        .setRequiredCount(wop.getPartCount());
+                partRequirements.add(partRequirement);
+            }
+            model.partRequirements = partRequirements;
+        }
+
+        return model;
+    }
+
+    private static boolean isReadyToStart(WorkOrderEntity workOrder) {
+        // Work order is "ready to start" if there is sufficient inventory for all required parts
+        return workOrder.getParts().stream()
+                .allMatch(wop -> wop.getPart().getInventory() >= wop.getPartCount());
+    }
+}

--- a/backend/src/main/java/com/interview/repository/PartRepository.java
+++ b/backend/src/main/java/com/interview/repository/PartRepository.java
@@ -1,0 +1,18 @@
+package com.interview.repository;
+
+import com.interview.entity.PartEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PartRepository extends JpaRepository<PartEntity, Long> {
+    @Modifying
+    @Query("""
+       update PartEntity p
+       set p.inventory = p.inventory + :delta
+       where p.id = :id
+         and p.inventory + :delta >= 0
+    """)
+    int adjustInventory(@Param("id") Long id, @Param("delta") int delta);
+}

--- a/backend/src/main/java/com/interview/repository/WorkOrderPartRepository.java
+++ b/backend/src/main/java/com/interview/repository/WorkOrderPartRepository.java
@@ -1,7 +1,13 @@
 package com.interview.repository;
 
+import com.interview.entity.WorkOrderEntity;
 import com.interview.entity.WorkOrderPartEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface WorkOrderPartRepository extends JpaRepository<WorkOrderPartEntity, Long> {
+    @Query("SELECT wop.workOrder FROM WorkOrderPartEntity wop WHERE wop.part.id = :partId")
+    List<WorkOrderEntity> findWorkOrdersByPartId(Long partId);
 }

--- a/backend/src/main/java/com/interview/repository/WorkOrderPartRepository.java
+++ b/backend/src/main/java/com/interview/repository/WorkOrderPartRepository.java
@@ -1,0 +1,7 @@
+package com.interview.repository;
+
+import com.interview.entity.WorkOrderPartEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WorkOrderPartRepository extends JpaRepository<WorkOrderPartEntity, Long> {
+}

--- a/backend/src/main/java/com/interview/repository/WorkOrderRepository.java
+++ b/backend/src/main/java/com/interview/repository/WorkOrderRepository.java
@@ -1,0 +1,7 @@
+package com.interview.repository;
+
+import com.interview.entity.WorkOrderEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WorkOrderRepository extends JpaRepository<WorkOrderEntity, Long> {
+}

--- a/backend/src/main/java/com/interview/service/PartService.java
+++ b/backend/src/main/java/com/interview/service/PartService.java
@@ -4,6 +4,7 @@ import com.interview.exception.BadRequestException;
 import com.interview.exception.ResourceNotFoundException;
 import com.interview.model.Part;
 import com.interview.repository.PartRepository;
+import com.interview.repository.WorkOrderPartRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,6 +17,7 @@ import java.util.Optional;
 @AllArgsConstructor
 public class PartService {
     private final PartRepository partRepository;
+    private final WorkOrderPartRepository workOrderPartRepository;
 
     public Optional<Part> get(Long partId) {
         return partRepository.findById(partId).map(Part::fromEntity);
@@ -69,6 +71,9 @@ public class PartService {
 
     @Transactional
     public void delete(Long partId) {
+        if (!workOrderPartRepository.findWorkOrdersByPartId(partId).isEmpty()) {
+            throw new BadRequestException("Unable to delete Part with id " + partId + ". Part is still in use.");
+        }
         partRepository.deleteById(partId);
     }
 }

--- a/backend/src/main/java/com/interview/service/PartService.java
+++ b/backend/src/main/java/com/interview/service/PartService.java
@@ -1,0 +1,74 @@
+package com.interview.service;
+
+import com.interview.exception.BadRequestException;
+import com.interview.exception.ResourceNotFoundException;
+import com.interview.model.Part;
+import com.interview.repository.PartRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@AllArgsConstructor
+public class PartService {
+    private final PartRepository partRepository;
+
+    public Optional<Part> get(Long partId) {
+        return partRepository.findById(partId).map(Part::fromEntity);
+    }
+
+    public Page<Part> getAll(Pageable pageable) {
+        return partRepository.findAll(pageable)
+                .map(Part::fromEntity);
+    }
+
+    @Transactional
+    public Part adjustInventory(Long partId, int delta) {
+        if (!partRepository.existsById(partId)) {
+            throw new ResourceNotFoundException("Part not found: " + partId);
+        }
+
+        if (delta == 0) {
+            return get(partId)
+                    .orElseThrow(() -> new ResourceNotFoundException("Part not found: " + partId));
+        }
+
+        // adjustInventory returns the # of updated rows, 0 indicates that no update was made
+        int updated = partRepository.adjustInventory(partId, delta);
+        if (updated == 0) {
+            throw new BadRequestException("Inventory update rejected for part " + partId);
+        }
+        return get(partId)
+                .orElseThrow(() -> new ResourceNotFoundException("Part not found after update: " + partId));
+    }
+
+    @Transactional
+    public Part create(Part part) {
+        var entity = part.toEntity();
+        entity.setId(null); // ID will be set by DB
+        var created = partRepository.save(entity);
+        return Part.fromEntity(created);
+    }
+
+    @Transactional
+    public Part update(Part part) {
+        if (part.getId() == null) {
+            throw new BadRequestException("Part ID is required for update");
+        }
+        var existing = partRepository.findById(part.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Part not found: " + part.getId()));
+        existing.setName(part.getName());
+
+        var updated = partRepository.save(existing);
+        return Part.fromEntity(updated);
+    }
+
+    @Transactional
+    public void delete(Long partId) {
+        partRepository.deleteById(partId);
+    }
+}

--- a/backend/src/main/java/com/interview/service/WorkOrderService.java
+++ b/backend/src/main/java/com/interview/service/WorkOrderService.java
@@ -1,0 +1,55 @@
+package com.interview.service;
+
+import com.interview.exception.BadRequestException;
+import com.interview.exception.ResourceNotFoundException;
+import com.interview.model.WorkOrder;
+import com.interview.repository.WorkOrderRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@AllArgsConstructor
+public class WorkOrderService {
+    private final WorkOrderRepository workOrderRepository;
+
+    public Optional<WorkOrder> get(Long id) {
+        return workOrderRepository.findById(id)
+                .map(WorkOrder::fromEntity);
+    }
+
+    public Page<WorkOrder> getAll(Pageable pageable) {
+        return workOrderRepository.findAll(pageable)
+                .map(WorkOrder::fromEntity);
+    }
+
+    @Transactional
+    public WorkOrder create(WorkOrder workOrder) {
+        var entity = workOrder.toEntity();
+        entity.setId(null); // ID will be set by DB
+        var created = workOrderRepository.save(entity);
+        return WorkOrder.fromEntity(created);
+    }
+
+    @Transactional
+    public WorkOrder update(WorkOrder workOrder) {
+        if (workOrder.getId() == null) {
+            throw new BadRequestException("WorkOrder ID is required for update");
+        }
+        var existing = workOrderRepository.findById(workOrder.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("WorkOrder not found: " + workOrder.getId()));
+        existing.setParts(workOrder.toEntity().getParts());
+
+        var updated = workOrderRepository.save(existing);
+        return WorkOrder.fromEntity(updated);
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        workOrderRepository.deleteById(id);
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -3,4 +3,7 @@ spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=password
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.defer-datasource-initialization=true
+spring.sql.init.mode=always
 spring.h2.console.enabled=true
+server.error.include-message=always

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,0 +1,31 @@
+-- Provide SQL scripts here
+INSERT INTO parts (id, name, inventory)
+VALUES
+    (1, 'Bolt M8 x 30mm', 200),
+    (2, 'Washer M8', 200),
+    (3, 'Nut M8', 200),
+    (4, 'Nut M6', 200),
+    (5, 'Washer M6', 200),
+    (6, 'Bolt M6 x 20mm', 200);
+
+INSERT INTO work_orders (id)
+VALUES
+    (1),
+    (2),
+    (3);
+
+INSERT INTO work_order_parts (id, work_order_id, part_id, part_count)
+VALUES
+    (1, 1, 1, 20),
+    (2, 1, 2, 20),
+    (3, 1, 3, 20),
+    (4, 2, 4, 30),
+    (5, 2, 5, 30),
+    (6, 2, 6, 30),
+    (7, 3, 1, 70),
+    (8, 3, 2, 70),
+    (9, 3, 3, 70),
+    (10, 3, 4, 300),
+    (11, 3, 5, 300),
+    (12, 3, 6, 300);
+

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,31 +1,31 @@
 -- Provide SQL scripts here
-INSERT INTO parts (id, name, inventory)
+INSERT INTO parts (name, inventory)
 VALUES
-    (1, 'Bolt M8 x 30mm', 200),
-    (2, 'Washer M8', 200),
-    (3, 'Nut M8', 200),
-    (4, 'Nut M6', 200),
-    (5, 'Washer M6', 200),
-    (6, 'Bolt M6 x 20mm', 200);
+    ('Bolt M8 x 30mm', 200),
+    ('Washer M8', 200),
+    ('Nut M8', 200),
+    ('Nut M6', 200),
+    ('Washer M6', 200),
+    ('Bolt M6 x 20mm', 200);
 
-INSERT INTO work_orders (id)
+INSERT INTO work_orders ()
 VALUES
-    (1),
-    (2),
-    (3);
+    (),
+    (),
+    ();
 
-INSERT INTO work_order_parts (id, work_order_id, part_id, part_count)
+INSERT INTO work_order_parts (work_order_id, part_id, part_count)
 VALUES
-    (1, 1, 1, 20),
-    (2, 1, 2, 20),
-    (3, 1, 3, 20),
-    (4, 2, 4, 30),
-    (5, 2, 5, 30),
-    (6, 2, 6, 30),
-    (7, 3, 1, 70),
-    (8, 3, 2, 70),
-    (9, 3, 3, 70),
-    (10, 3, 4, 300),
-    (11, 3, 5, 300),
-    (12, 3, 6, 300);
+    (1, 1, 20),
+    (1, 2, 20),
+    (1, 3, 20),
+    (2, 4, 30),
+    (2, 5, 30),
+    (2, 6, 30),
+    (3, 1, 70),
+    (3, 2, 70),
+    (3, 3, 70),
+    (3, 4, 300),
+    (3, 5, 300),
+    (3, 6, 300);
 

--- a/backend/src/main/resources/database/data.sql
+++ b/backend/src/main/resources/database/data.sql
@@ -1,1 +1,0 @@
--- Provide SQL scripts here

--- a/backend/src/test/java/com/interview/integration/CrudIntegrationTest.java
+++ b/backend/src/test/java/com/interview/integration/CrudIntegrationTest.java
@@ -1,0 +1,73 @@
+package com.interview.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.interview.model.Part;
+import com.interview.util.PartOperations;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.interview.util.UtilityMethods.fromMvcResult;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional // Resets DB state after each test
+public class CrudIntegrationTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Autowired
+    MockMvc mvc;
+
+    PartOperations partOperations;
+
+    @BeforeEach
+    void setUp() {
+        partOperations = new PartOperations(mvc, objectMapper); // Included in setup call to ensure MockMvc is initialized
+    }
+
+    @Test
+    void contextLoads() {
+    }
+
+    @Test
+    void getPart_shouldReturnPart() throws Exception {
+        mvc.perform(get("/api/part/{partId}", 1))
+                .andExpect(status().isOk())
+                .andExpect(content().json("{\"id\":1,\"name\":\"Bolt M8 x 30mm\",\"inventory\":200}"));
+    }
+
+    @Test
+    void deletePart_shouldFail_whenPartIsUsedByWorkOrder() throws Exception {
+        mvc.perform(delete("/api/part/{partId}", 1))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void testCreateUpdateDeletePart() throws Exception {
+        var newPart = partOperations.createPart(new Part().setName("Doodad"));
+
+        assertThat(newPart.getName()).isEqualTo("Doodad");
+        assertThat(newPart.getInventory()).isEqualTo(0);
+
+        var partId = newPart.getId();
+
+        partOperations.updatePart(partId, new Part().setName("Thing-a-ma-bob"));
+
+        var updatedPart = partOperations.getPart(partId);
+
+        assertThat(updatedPart.getName()).isEqualTo("Thing-a-ma-bob");
+
+        partOperations.deletePart(partId);
+
+        mvc.perform(get("/api/part/{partId}", partId))
+                .andExpect(status().isNotFound()); // After deletion, part should no longer be found
+    }
+}

--- a/backend/src/test/java/com/interview/model/WorkOrderTest.java
+++ b/backend/src/test/java/com/interview/model/WorkOrderTest.java
@@ -1,0 +1,48 @@
+package com.interview.model;
+
+import com.interview.entity.PartEntity;
+import com.interview.entity.WorkOrderEntity;
+import com.interview.entity.WorkOrderPartEntity;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WorkOrderTest {
+    @Test
+    void isReadyToStart_shouldReturnFalse_whenPartHasInsufficientInventory() {
+        var workOrder = new WorkOrderEntity()
+                .setParts(List.of(
+                        new WorkOrderPartEntity()
+                                .setPartCount(5)
+                                .setPart(new PartEntity(1L, "foo", 6)),
+                        new WorkOrderPartEntity()
+                                .setPartCount(10)
+                                .setPart(new PartEntity(2L, "bar", 20)),
+                        new WorkOrderPartEntity()
+                                .setPartCount(30)
+                                .setPart(new PartEntity(3L, "baz", 29))
+                ));
+
+        assertThat(WorkOrder.isReadyToStart(workOrder)).isFalse();
+    }
+
+    @Test
+    void isReadyToStart_shouldReturnTrue_whenPartHasSufficientInventory() {
+        var workOrder = new WorkOrderEntity()
+                .setParts(List.of(
+                        new WorkOrderPartEntity()
+                                .setPartCount(5)
+                                .setPart(new PartEntity(1L, "foo", 6)),
+                        new WorkOrderPartEntity()
+                                .setPartCount(10)
+                                .setPart(new PartEntity(2L, "bar", 20)),
+                        new WorkOrderPartEntity()
+                                .setPartCount(30)
+                                .setPart(new PartEntity(3L, "baz", 31))
+                ));
+
+        assertThat(WorkOrder.isReadyToStart(workOrder)).isTrue();
+    }
+}

--- a/backend/src/test/java/com/interview/util/PartOperations.java
+++ b/backend/src/test/java/com/interview/util/PartOperations.java
@@ -1,0 +1,54 @@
+package com.interview.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.interview.model.Part;
+import lombok.AllArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.interview.util.UtilityMethods.fromMvcResult;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AllArgsConstructor
+public class PartOperations {
+    private final MockMvc mvc;
+    private final ObjectMapper om;
+
+    public Part getPart(Long id) throws Exception {
+        var result = mvc.perform(get("/api/part/{partId}", id))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        return fromMvcResult(result, Part.class);
+    }
+
+    public Part createPart(Part part) throws Exception {
+        var result = mvc.perform(
+                        post("/api/part")
+                                .content(om.writeValueAsString(part))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        return fromMvcResult(result, Part.class);
+    }
+
+    public Part updatePart(Long id, Part part) throws Exception {
+        var result = mvc.perform(
+                        put("/api/part/{partId}", id)
+                                .content(om.writeValueAsString(part))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        return fromMvcResult(result, Part.class);
+    }
+
+    public void deletePart(Long id) throws Exception {
+        mvc.perform(delete("/api/part/{partId}", id))
+                .andExpect(status().isOk())
+                .andReturn();
+    }
+}

--- a/backend/src/test/java/com/interview/util/UtilityMethods.java
+++ b/backend/src/test/java/com/interview/util/UtilityMethods.java
@@ -1,0 +1,13 @@
+package com.interview.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.test.web.servlet.MvcResult;
+
+public class UtilityMethods {
+    private static ObjectMapper objectMapper = new ObjectMapper();
+
+    public static <T> T fromMvcResult(MvcResult result, Class<T> clazz) throws Exception {
+        String json = result.getResponse().getContentAsString();
+        return objectMapper.readValue(json, clazz);
+    }
+}


### PR DESCRIPTION
For my CRUD application I imagine a system for tracking parts that are used for work orders. Each part includes an inventory number to track how many are available and each work order includes a list of required parts and the number of each part required. A work order is "ready" when there is enough inventory of each required part.

If I were to spend more time on this project some other things that I would have added:
- The ability to "start" a work order which would automatically deplete the supply of available parts
- A triggered job (in a real system it would probably be scheduled) that would look at all the current work orders and put together an order for additional parts
- Additional automated testing for the work order CRUD components

Other obvious improvements would be to allow multiple "locations" associated with parts and work orders, possibly inventory management between locations to avoid ordering parts that are already available at a different location. I also assumed usage would be single tenant but a multi-tenant setup would be possible with some small additions to the data model.