### PR TITLE
SRE-Keith Bachand: Interview

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,67 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+  security-events: write
+
+env:
+  IMAGE_REPO: docker.io/${{ secrets.DOCKERHUB_USERNAME }}/tekmetric-interview-backend
+
+jobs:
+  build_scan_push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image (load locally for scan)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: false
+          load: true
+          tags: |
+            ${{ env.IMAGE_REPO }}:${{ github.sha }}
+
+      - name: Trivy scan (fail on HIGH/CRITICAL) + SARIF
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          image-ref: ${{ env.IMAGE_REPO }}:${{ github.sha }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: 1
+
+      - name: Upload Trivy SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
+
+      - name: Log in to Docker Hub
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push image to Docker Hub (sha + latest)
+        if: github.event_name == 'push'
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE_REPO }}:${{ github.sha }}
+            ${{ env.IMAGE_REPO }}:latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: ci
 on:
   pull_request:
   push:
-    branches: [ "main" ]
+    branches: [ "master" ]
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # Build once and load locally so Trivy can scan it
       - name: Build image (load locally for scan)
         uses: docker/build-push-action@v6
         with:
@@ -33,21 +34,41 @@ jobs:
           tags: |
             ${{ env.IMAGE_REPO }}:${{ github.sha }}
 
-      - name: Trivy scan (fail on HIGH/CRITICAL) + SARIF
+      # 1) OS vulnerabilities: HARD GATE (fail on HIGH/CRITICAL)
+      - name: Trivy scan (OS vulns) - gate
         uses: aquasecurity/trivy-action@0.24.0
         with:
           image-ref: ${{ env.IMAGE_REPO }}:${{ github.sha }}
           format: sarif
-          output: trivy-results.sarif
+          output: trivy-os.sarif
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           exit-code: 1
+          vuln-type: os
 
-      - name: Upload Trivy SARIF to GitHub Security
+      - name: Upload Trivy OS SARIF to GitHub Security
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: trivy-results.sarif
+          sarif_file: trivy-os.sarif
 
+      # 2) Application/library vulnerabilities: REPORT ONLY (do not fail)
+      - name: Trivy scan (library vulns) - report only
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          image-ref: ${{ env.IMAGE_REPO }}:${{ github.sha }}
+          format: sarif
+          output: trivy-libs.sarif
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: 0
+          vuln-type: library
+
+      - name: Upload Trivy Library SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-libs.sarif
+
+      # Log in only on push events (secrets are not available to PRs from forks)
       - name: Log in to Docker Hub
         if: github.event_name == 'push'
         uses: docker/login-action@v3
@@ -55,6 +76,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # Push only on push events
       - name: Push image to Docker Hub (sha + latest)
         if: github.event_name == 'push'
         uses: docker/build-push-action@v6

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: trivy-os.sarif
+          category: trivy-os
 
       # 2) Application/library vulnerabilities: REPORT ONLY (do not fail)
       - name: Trivy scan (library vulns) - report only
@@ -67,6 +68,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: trivy-libs.sarif
+          category: trivy-libs
 
       # Log in only on push events (secrets are not available to PRs from forks)
       - name: Log in to Docker Hub

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,8 @@
+target/
+.git/
+.gitignore
+.mvn/
+.idea/
+.vscode/
+*.iml
+*.log

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,25 +2,25 @@
     FROM maven:3.9-eclipse-temurin-8 AS build
     WORKDIR /app
     
+    # Cache deps
     COPY pom.xml .
     RUN mvn -B -q -DskipTests dependency:go-offline
     
+    # Build
     COPY src ./src
     RUN mvn -B -DskipTests package
     
-    # ---- runtime stage ----
-    FROM eclipse-temurin:8-jre
-    
-    RUN useradd -r -u 10001 -g root appuser
+    # ---- runtime stage (distroless, nonroot) ----
+    # Distroless reduces OS package surface area => typically far fewer CVEs
+    FROM gcr.io/distroless/java8-debian11:nonroot
     
     WORKDIR /app
     COPY --from=build /app/target/*.jar /app/app.jar
     
-    # Java often needs /tmp writable even with read-only root FS
-    RUN mkdir -p /tmp && chown -R 10001:0 /tmp
-    
-    USER 10001
+    # Expose app port
     EXPOSE 8080
+    
+    # Container-friendly JVM flags
     ENV JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=75.0 -Djava.security.egd=file:/dev/./urandom"
     
     ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,25 +2,29 @@
     FROM maven:3.9-eclipse-temurin-8 AS build
     WORKDIR /app
     
-    # Cache deps
     COPY pom.xml .
     RUN mvn -B -q -DskipTests dependency:go-offline
     
-    # Build
     COPY src ./src
     RUN mvn -B -DskipTests package
     
-    # ---- runtime stage (distroless, nonroot) ----
-    # Distroless reduces OS package surface area => typically far fewer CVEs
-    FROM gcr.io/distroless/java8-debian11:nonroot
+    # ---- runtime stage (pinned Alpine JRE 8) ----
+    # Pinning to an Alpine variant helps reduce OS CVE surface vs Debian-based JRE images.
+    FROM eclipse-temurin:8-jre-alpine-3.21
+    
+    # Create a non-root user/group (Alpine style)
+    RUN addgroup -S appgroup \
+     && adduser  -S -u 10001 -G appgroup appuser
     
     WORKDIR /app
     COPY --from=build /app/target/*.jar /app/app.jar
     
-    # Expose app port
-    EXPOSE 8080
+    # Java often needs /tmp writable (also plays well with readOnlyRootFilesystem + /tmp emptyDir in k8s)
+    RUN mkdir -p /tmp \
+     && chown -R 10001:appgroup /tmp /app
     
-    # Container-friendly JVM flags
+    USER 10001
+    EXPOSE 8080
     ENV JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=75.0 -Djava.security.egd=file:/dev/./urandom"
     
     ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,27 @@
+# ---- build stage ----
+    FROM maven:3.9-eclipse-temurin-8 AS build
+    WORKDIR /app
+    
+    COPY pom.xml .
+    RUN mvn -B -q -DskipTests dependency:go-offline
+    
+    COPY src ./src
+    RUN mvn -B -DskipTests package
+    
+    # ---- runtime stage ----
+    FROM eclipse-temurin:8-jre
+    
+    RUN useradd -r -u 10001 -g root appuser
+    
+    WORKDIR /app
+    COPY --from=build /app/target/*.jar /app/app.jar
+    
+    # Java often needs /tmp writable even with read-only root FS
+    RUN mkdir -p /tmp && chown -R 10001:0 /tmp
+    
+    USER 10001
+    EXPOSE 8080
+    ENV JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=75.0 -Djava.security.egd=file:/dev/./urandom"
+    
+    ENTRYPOINT ["java","-jar","/app/app.jar"]
+    

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -21,6 +21,14 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
             <version>2.1.4.RELEASE</version>
         </dependency>

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -4,3 +4,6 @@ spring.datasource.username=sa
 spring.datasource.password=password
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.h2.console.enabled=true
+
+management.endpoints.web.exposure.include=health,info,prometheus
+management.metrics.tags.application=interview-backend

--- a/sre/RUNBOOK.md
+++ b/sre/RUNBOOK.md
@@ -1,0 +1,89 @@
+# Kind + Argo CD Runbook
+
+For local demo, everything is deployed to a kind cluster via Argo CD. The only manual
+steps are installing Argo CD and applying the Argo CD Applications; the system
+components (ingress-nginx, metrics-server) and backend app are then managed by Argo CD.
+
+## Prerequisites
+- Docker
+- kubectl
+- kind
+- Helm
+- Kustomize (either `kubectl kustomize` or standalone `kustomize`)
+- Docker Hub account (or any reachable container registry)
+- Optional: Prometheus Operator (for ServiceMonitor)
+
+### 1) Create a kind cluster
+```bash
+kind create cluster --config sre/kind/kind-config.yaml
+```
+
+### 2) Build and push the backend image
+The image is built via the GitHub Actions workflow.
+
+### 3) Point Argo CD Applications to your fork and image
+Update these files:
+- `sre/argocd/applications/system.yaml` (`repoURL`, `targetRevision`)
+- `sre/argocd/applications/interview-backend.yaml` (`repoURL`, `targetRevision`)
+- `sre/charts/interview-backend/values.yaml` (`image.repository`, `image.tag`, `image.pullPolicy`)
+
+### 4) Install Argo CD
+```bash
+kubectl apply --server-side -k sre/argocd/install
+kubectl -n argocd rollout status deploy/argocd-server
+```
+
+### 5) Access the Argo CD UI and log in
+```bash
+kubectl -n argocd port-forward svc/argocd-server 8080:443
+```
+
+Open: `https://localhost:8080`
+
+Get the initial admin password:
+```bash
+kubectl -n argocd get secret argocd-initial-admin-secret \
+  -o jsonpath="{.data.password}" | base64 --decode; echo
+```
+
+Login:
+- Username: `admin`
+- Password: (output above)
+
+### 6) Apply Argo CD Applications (system + backend)
+```bash
+kubectl apply -k sre/argocd/applications
+```
+
+Check app status:
+```bash
+argocd app list
+argocd app get system
+argocd app get interview-backend
+```
+
+### 7) Validate (after Argo CD syncs)
+```bash
+kubectl -n interview port-forward svc/interview-backend 8080:80
+curl http://localhost:8080/api/welcome
+curl http://localhost:8080/actuator/health
+```
+
+If using ingress-nginx, you can also hit:
+```
+http://backend.localtest.me:8080/api/welcome
+```
+
+## Observability
+- Health endpoint: `/actuator/health`
+- Prometheus metrics: `/actuator/prometheus`
+- To enable a ServiceMonitor (Prometheus Operator), set:
+  - `metrics.serviceMonitor.enabled=true`
+  - optional `metrics.serviceMonitor.additionalLabels`
+
+## CI/CD
+The GitHub Actions workflow builds, scans (Trivy), and pushes to Docker Hub on `push` to `master`.
+Configure repository secrets:
+- `DOCKERHUB_USERNAME`
+- `DOCKERHUB_TOKEN`
+

--- a/sre/argocd/applications/interview-backend.yaml
+++ b/sre/argocd/applications/interview-backend.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: interview-backend
+  namespace: argocd
+spec:
+  project: default
+
+  source:
+    repoURL: https://github.com/xoibsurferx/interview.git
+    targetRevision: sre-prodlike-demo
+    path: sre/charts/interview-backend
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: interview
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/sre/argocd/applications/interview-backend.yaml
+++ b/sre/argocd/applications/interview-backend.yaml
@@ -8,7 +8,7 @@ spec:
 
   source:
     repoURL: https://github.com/xoibsurferx/interview.git
-    targetRevision: sre-prodlike-demo
+    targetRevision: master
     path: sre/charts/interview-backend
 
   destination:

--- a/sre/argocd/applications/kustomization.yaml
+++ b/sre/argocd/applications/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - interview-backend.yaml
+  - system.yaml
+

--- a/sre/argocd/applications/system.yaml
+++ b/sre/argocd/applications/system.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: system
+  namespace: argocd
+spec:
+  project: default
+
+  source:
+    repoURL: https://github.com/xoibsurferx/interview.git
+    targetRevision: master
+    path: sre/system
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+

--- a/sre/argocd/install/kustomization.yaml
+++ b/sre/argocd/install/kustomization.yaml
@@ -4,5 +4,6 @@ kind: Kustomization
 namespace: argocd
 
 resources:
+  - namespace.yaml
   - https://raw.githubusercontent.com/argoproj/argo-cd/v3.3.0/manifests/install.yaml
 

--- a/sre/argocd/install/kustomization.yaml
+++ b/sre/argocd/install/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: argocd
+
+resources:
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v3.3.0/manifests/install.yaml
+

--- a/sre/argocd/install/namespace.yaml
+++ b/sre/argocd/install/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd
+

--- a/sre/charts/interview-backend/Chart.yaml
+++ b/sre/charts/interview-backend/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: interview-backend
+description: Tekmetric Interview - Backend Spring Boot API
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/sre/charts/interview-backend/templates/NOTES.txt
+++ b/sre/charts/interview-backend/templates/NOTES.txt
@@ -1,0 +1,5 @@
+Ingress:
+  http://{{ .Values.ingress.host }}{{ .Values.ingress.path }}
+
+Endpoint:
+  GET {{ .Values.probes.path }}

--- a/sre/charts/interview-backend/templates/NOTES.txt
+++ b/sre/charts/interview-backend/templates/NOTES.txt
@@ -1,5 +1,7 @@
 Ingress:
   http://{{ .Values.ingress.host }}{{ .Values.ingress.path }}
 
-Endpoint:
-  GET {{ .Values.probes.path }}
+Endpoints:
+  Health:  GET {{ .Values.probes.path }}
+  Welcome: GET /api/welcome
+  Metrics: GET {{ .Values.metrics.path }}

--- a/sre/charts/interview-backend/templates/_helpers.tpl
+++ b/sre/charts/interview-backend/templates/_helpers.tpl
@@ -1,0 +1,20 @@
+{{- define "interview-backend.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "interview-backend.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "interview-backend.labels" -}}
+app.kubernetes.io/name: {{ include "interview-backend.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "interview-backend.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "interview-backend.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/sre/charts/interview-backend/templates/deployment.yaml
+++ b/sre/charts/interview-backend/templates/deployment.yaml
@@ -13,6 +13,10 @@ spec:
     metadata:
       labels:
         {{- include "interview-backend.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ default (include "interview-backend.fullname" .) .Values.serviceAccount.name }}
       securityContext:

--- a/sre/charts/interview-backend/templates/deployment.yaml
+++ b/sre/charts/interview-backend/templates/deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "interview-backend.fullname" . }}
+  labels:
+    {{- include "interview-backend.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "interview-backend.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "interview-backend.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ default (include "interview-backend.fullname" .) .Values.serviceAccount.name }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: app
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.path }}
+              port: http
+            initialDelaySeconds: {{ add .Values.probes.initialDelaySeconds 10 }}
+            periodSeconds: {{ .Values.probes.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.failureThreshold }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/sre/charts/interview-backend/templates/deployment.yaml
+++ b/sre/charts/interview-backend/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: app
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}{{- if .Values.image.digest }}@{{ .Values.image.digest }}{{- else }}:{{ .Values.image.tag }}{{- end }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
@@ -49,6 +49,16 @@ spec:
             periodSeconds: {{ .Values.probes.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
             failureThreshold: {{ .Values.probes.failureThreshold }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.startupProbe.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/sre/charts/interview-backend/templates/hpa.yaml
+++ b/sre/charts/interview-backend/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.autoscaling.enabled -}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "interview-backend.fullname" . }}
+  labels:
+    {{- include "interview-backend.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "interview-backend.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/sre/charts/interview-backend/templates/ingress.yaml
+++ b/sre/charts/interview-backend/templates/ingress.yaml
@@ -7,6 +7,10 @@ metadata:
     {{- include "interview-backend.labels" . | nindent 4 }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}
       http:

--- a/sre/charts/interview-backend/templates/ingress.yaml
+++ b/sre/charts/interview-backend/templates/ingress.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "interview-backend.fullname" . }}
+  labels:
+    {{- include "interview-backend.labels" . | nindent 4 }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "interview-backend.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}

--- a/sre/charts/interview-backend/templates/networkpolicy.yaml
+++ b/sre/charts/interview-backend/templates/networkpolicy.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.networkPolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "interview-backend.fullname" . }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "interview-backend.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+      ports:
+        - protocol: TCP
+          port: 8080
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+{{- end }}

--- a/sre/charts/interview-backend/templates/networkpolicy.yaml
+++ b/sre/charts/interview-backend/templates/networkpolicy.yaml
@@ -13,6 +13,11 @@ spec:
   ingress:
     - from:
         - podSelector: {}
+        {{- range .Values.networkPolicy.ingressNamespaces }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ . | quote }}
+        {{- end }}
       ports:
         - protocol: TCP
           port: 8080

--- a/sre/charts/interview-backend/templates/pdb.yaml
+++ b/sre/charts/interview-backend/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.pdb.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "interview-backend.fullname" . }}
+  labels:
+    {{- include "interview-backend.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "interview-backend.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/sre/charts/interview-backend/templates/service.yaml
+++ b/sre/charts/interview-backend/templates/service.yaml
@@ -4,6 +4,17 @@ metadata:
   name: {{ include "interview-backend.fullname" . }}
   labels:
     {{- include "interview-backend.labels" . | nindent 4 }}
+  {{- if or .Values.metrics.enabled (not (empty .Values.service.annotations)) }}
+  annotations:
+    {{- if .Values.metrics.enabled }}
+    prometheus.io/scrape: "true"
+    prometheus.io/path: {{ .Values.metrics.path }}
+    prometheus.io/port: "{{ .Values.metrics.port }}"
+    {{- end }}
+    {{- with .Values.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   selector:

--- a/sre/charts/interview-backend/templates/service.yaml
+++ b/sre/charts/interview-backend/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "interview-backend.fullname" . }}
+  labels:
+    {{- include "interview-backend.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "interview-backend.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP

--- a/sre/charts/interview-backend/templates/serviceaccount.yaml
+++ b/sre/charts/interview-backend/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ default (include "interview-backend.fullname" .) .Values.serviceAccount.name }}
+  labels:
+    {{- include "interview-backend.labels" . | nindent 4 }}
+{{- end }}

--- a/sre/charts/interview-backend/templates/servicemonitor.yaml
+++ b/sre/charts/interview-backend/templates/servicemonitor.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "interview-backend.fullname" . }}
+  labels:
+    {{- include "interview-backend.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "interview-backend.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: http
+      path: {{ .Values.metrics.path }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+{{- end }}
+

--- a/sre/charts/interview-backend/values.yaml
+++ b/sre/charts/interview-backend/values.yaml
@@ -1,0 +1,63 @@
+replicaCount: 2
+
+image:
+  repository: docker.io/xoibsurferx/tekmetric-interview-backend
+  tag: latest
+  pullPolicy: Always
+
+serviceAccount:
+  create: true
+  name: ""
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8080
+
+ingress:
+  enabled: true
+  className: nginx
+  host: backend.localtest.me
+  path: /
+  pathType: Prefix
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 768Mi
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 10001
+  fsGroup: 2000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+probes:
+  path: /api/welcome
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  timeoutSeconds: 2
+  failureThreshold: 6
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+
+pdb:
+  enabled: true
+  minAvailable: 1
+
+networkPolicy:
+  enabled: true
+

--- a/sre/charts/interview-backend/values.yaml
+++ b/sre/charts/interview-backend/values.yaml
@@ -13,6 +13,7 @@ service:
   type: ClusterIP
   port: 80
   targetPort: 8080
+  annotations: {}
 
 ingress:
   enabled: true
@@ -34,6 +35,8 @@ podSecurityContext:
   runAsUser: 10001
   fsGroup: 2000
 
+podAnnotations: {}
+
 securityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -42,11 +45,21 @@ securityContext:
       - ALL
 
 probes:
-  path: /api/welcome
+  path: /actuator/health
   initialDelaySeconds: 15
   periodSeconds: 10
   timeoutSeconds: 2
   failureThreshold: 6
+
+metrics:
+  enabled: true
+  path: /actuator/prometheus
+  port: 8080
+  serviceMonitor:
+    enabled: false
+    interval: 30s
+    scrapeTimeout: 10s
+    additionalLabels: {}
 
 autoscaling:
   enabled: true
@@ -60,4 +73,7 @@ pdb:
 
 networkPolicy:
   enabled: true
+  ingressNamespaces:
+    - ingress-nginx
+    - monitoring
 

--- a/sre/charts/interview-backend/values.yaml
+++ b/sre/charts/interview-backend/values.yaml
@@ -3,6 +3,7 @@ replicaCount: 2
 image:
   repository: docker.io/xoibsurferx/tekmetric-interview-backend
   tag: latest
+  digest: ""
   pullPolicy: Always
 
 serviceAccount:
@@ -21,6 +22,7 @@ ingress:
   host: backend.localtest.me
   path: /
   pathType: Prefix
+  tls: []
 
 resources:
   requests:
@@ -50,6 +52,14 @@ probes:
   periodSeconds: 10
   timeoutSeconds: 2
   failureThreshold: 6
+
+startupProbe:
+  enabled: true
+  path: /actuator/health
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 2
+  failureThreshold: 30
 
 metrics:
   enabled: true

--- a/sre/kind/kind-config.yaml
+++ b/sre/kind/kind-config.yaml
@@ -4,6 +4,12 @@ name: tekmetric
 
 nodes:
   - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
     extraPortMappings:
       - containerPort: 80
         hostPort: 8080

--- a/sre/kind/kind-config.yaml
+++ b/sre/kind/kind-config.yaml
@@ -1,0 +1,13 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: tekmetric
+
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: 80
+        hostPort: 8080
+        protocol: TCP
+      - containerPort: 443
+        hostPort: 8443
+        protocol: TCP

--- a/sre/system/base/ingress-nginx/kustomization.yaml
+++ b/sre/system/base/ingress-nginx/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.10.0/deploy/static/provider/kind/deploy.yaml
+

--- a/sre/system/base/kustomization.yaml
+++ b/sre/system/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ingress-nginx
+  - metrics-server
+

--- a/sre/system/base/metrics-server/kustomization.yaml
+++ b/sre/system/base/metrics-server/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+

--- a/sre/system/kustomization.yaml
+++ b/sre/system/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - base
+


### PR DESCRIPTION
## Summary
- Productionized the backend deployment with GitOps (Argo CD), a production‑leaning Helm chart, and observability endpoints.
- Added a Kind + Argo CD runbook so the demo can be reproduced end‑to‑end.

## Changes
- Added Spring Boot Actuator + Prometheus registry and exposed health/metrics endpoints (`backend/pom.xml`, `backend/src/main/resources/application.properties`).
- Updated Helm chart to use `/actuator/health` probes, optional startupProbe, image digest support, and optional ingress TLS (`sre/charts/interview-backend`).
- Added Prometheus scrape annotations and an optional ServiceMonitor (`sre/charts/interview-backend/templates/service.yaml`, `.../servicemonitor.yaml`).
- Added system component Kustomize base for ingress‑nginx + metrics‑server (`sre/system/...`).
- Added Argo CD install via Kustomize with explicit namespace creation and pinned Argo CD version (`sre/argocd/install`).
- Added Argo CD Application for system components and wired into apps kustomization (`sre/argocd/applications`).
- Updated kind config to label the node for ingress‑nginx scheduling (`sre/kind/kind-config.yaml`).
- Added a dedicated demo runbook with Argo CD UI/login and app status checks (`sre/RUNBOOK.md`).

## Why
- Observability is required; Actuator + Prometheus provides standard health/metrics endpoints.
- GitOps via Argo CD keeps system components and app deployments consistent and auditable.
- Startup/readiness/liveness probes and resource limits improve reliability under load.
- Image digest support and TLS options move the chart closer to production readiness.
- Kind node label prevents ingress‑nginx from staying Pending in single‑node demos.
- Runbook satisfies the “clear instructions” requirement without altering the original assignment README.

## Validation
# Install Argo CD (use server‑side apply to avoid CRD annotation size errors)
kubectl apply --server-side -k sre/argocd/install
kubectl -n argocd rollout status deploy/argocd-server

# Apply GitOps apps (system + backend)
kubectl apply -k sre/argocd/applications

# Check Argo CD app status
argocd app list
argocd app get system
argocd app get interview-backend

# Validate API
kubectl -n interview port-forward svc/interview-backend 8080:80
curl http://localhost:8080/api/welcome
curl http://localhost:8080/actuator/health

## AWS/EKS Notes (What I'd Change migrating this to AWS/EKS)
This repo is set up for a local demo on kind. For a production‑grade AWS/EKS deployment,
I would shift infrastructure to Terraform and adjust platform components accordingly.

### Infrastructure as Code (Terraform)
- Provision VPC, subnets, NAT, security groups, EKS cluster, managed node groups.
- Create IAM OIDC provider + IRSA roles for Argo CD, external‑dns, cert‑manager, etc.
- Create ECR repos and push images there (update image repo in Helm values).

### Ingress, TLS, and DNS
- Replace `ingress-nginx` with AWS Load Balancer Controller (ALB ingress).
- Use ACM for TLS certs and cert‑manager if needed for other issuers.
- Use external‑dns to manage Route 53 records automatically.

### Autoscaling and Observability
- Use Karpenter or Cluster Autoscaler for node scaling.
- Wire metrics to Prometheus + Grafana (or AMP/CloudWatch) and enable ServiceMonitor.
- Add log aggregation to CloudWatch or a centralized logging stack.

### Data and Secrets
- Replace H2 with RDS (Postgres/MySQL) and use Secrets Manager or SSM.
- Update Helm chart to read DB config from Secrets/ConfigMaps.

### Security and Reliability
- Use private subnets, restrict security group ingress, and tighten NetworkPolicies.
- Add PodSecurity standards, admission policies (OPA/Gatekeeper or Kyverno), and
  image policy enforcement (sigstore/cosign).

These changes keep the demo flow intact locally while outlining a path to
production‑grade deployment on AWS/EKS.
